### PR TITLE
Fix compilation on Windows with MinGW

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -210,6 +210,13 @@ endif()
 
 ### LIBRARIES ###
 
+if(WIN32 AND NOT MSVC)
+  # On MinGW ws2_32.dll needs explicit linking
+  # Also mswsock.dll is needed for AcceptEx() used by Boost.Asio
+  target_link_libraries(traintastic-server PRIVATE ws2_32 mswsock)
+  target_link_libraries(traintastic-server-test PRIVATE ws2_32 mswsock)
+endif()
+
 # boost
 if(LINUX)
   find_package(Boost 1.71 REQUIRED COMPONENTS program_options)
@@ -253,12 +260,17 @@ endif()
 # libarchive
 if(WIN32)
   set(LibArchive_INCLUDE_DIRS "thirdparty/libarchive/include")
-  set(LibArchive_LIBRARIES archive)
 
-  add_custom_command(TARGET traintastic-server PRE_LINK
-    COMMAND lib "/def:${PROJECT_SOURCE_DIR}/thirdparty/libarchive/bin/archive.def" /out:archive.lib /machine:x64)
-  add_custom_command(TARGET traintastic-server-test PRE_LINK
-    COMMAND lib "/def:${PROJECT_SOURCE_DIR}/thirdparty/libarchive/bin/archive.def" /out:archive.lib /machine:x64)
+  if(MSVC)
+      set(LibArchive_LIBRARIES archive)
+      add_custom_command(TARGET traintastic-server PRE_LINK
+        COMMAND lib "/def:${PROJECT_SOURCE_DIR}/thirdparty/libarchive/bin/archive.def" /out:archive.lib /machine:x64)
+      add_custom_command(TARGET traintastic-server-test PRE_LINK
+        COMMAND lib "/def:${PROJECT_SOURCE_DIR}/thirdparty/libarchive/bin/archive.def" /out:archive.lib /machine:x64)
+  else()
+      # MinGW can directly link .dll without import lib
+      set(LibArchive_LIBRARIES "${PROJECT_SOURCE_DIR}/thirdparty/libarchive/bin/archive.dll")
+  endif()
 
   # copy archive.dll to build directory:
   add_custom_command(TARGET traintastic-server POST_BUILD
@@ -278,12 +290,18 @@ target_link_libraries(traintastic-server-test PRIVATE ${LibArchive_LIBRARIES})
 if(WIN32)
   add_definitions(-DLUA_BUILD_AS_DLL)
   set(LUA_INCLUDE_DIR "thirdparty/lua5.3/include")
-  set(LUA_LIBRARIES lua53)
 
-  add_custom_command(TARGET traintastic-server PRE_LINK
-    COMMAND lib "/def:${PROJECT_SOURCE_DIR}/thirdparty/lua5.3/bin/win64/lua53.def" /out:lua53.lib /machine:x64)
-  add_custom_command(TARGET traintastic-server-test PRE_LINK
-    COMMAND lib "/def:${PROJECT_SOURCE_DIR}/thirdparty/lua5.3/bin/win64/lua53.def" /out:lua53.lib /machine:x64)
+  if(MSVC)
+      set(LUA_LIBRARIES lua53)
+      add_custom_command(TARGET traintastic-server PRE_LINK
+        COMMAND lib "/def:${PROJECT_SOURCE_DIR}/thirdparty/lua5.3/bin/win64/lua53.def" /out:lua53.lib /machine:x64)
+      add_custom_command(TARGET traintastic-server-test PRE_LINK
+        COMMAND lib "/def:${PROJECT_SOURCE_DIR}/thirdparty/lua5.3/bin/win64/lua53.def" /out:lua53.lib /machine:x64)
+  else()
+      # MinGW can directly link .dll without import lib
+      set(LUA_LIBRARIES "${PROJECT_SOURCE_DIR}/thirdparty/lua5.3/bin/win64/lua53.dll")
+  endif()
+
 
   # copy lua53.dll to build directory, to be able to run the tests:
   add_custom_command(TARGET traintastic-server-test POST_BUILD

--- a/server/src/os/windows/serialportlistimplwin32.cpp
+++ b/server/src/os/windows/serialportlistimplwin32.cpp
@@ -25,6 +25,12 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include "../../core/eventloop.hpp" // include before windows.h, else we get winsock header issues
 #include <windows.h>
+
+#if defined(__MINGW32__) || defined(__MINGW64__)
+//Needed for PHYSICAL_ADDRESS, used in ntddser.h
+#include <ntdef.h>
+#endif
+
 #include <ntddser.h>
 #include <setupapi.h>
 #include <dbt.h>

--- a/server/src/os/windows/trayicon.cpp
+++ b/server/src/os/windows/trayicon.cpp
@@ -241,7 +241,7 @@ LRESULT CALLBACK TrayIcon::windowProc(_In_ HWND hWnd, _In_ UINT uMsg, _In_ WPARA
   return DefWindowProc(hWnd, uMsg, wParam, lParam);
 }
 
-void TrayIcon::menuAddItem(MenuItem id, const LPSTR text, bool enabled)
+void TrayIcon::menuAddItem(MenuItem id, const LPCSTR text, bool enabled)
 {
   assert(s_menu);
   MENUITEMINFO item;

--- a/server/src/os/windows/trayicon.hpp
+++ b/server/src/os/windows/trayicon.hpp
@@ -67,7 +67,7 @@ class TrayIcon
     static void run(bool isRestart);
     static LRESULT CALLBACK windowProc(_In_ HWND hWnd, _In_ UINT uMsg, _In_ WPARAM wParam, _In_ LPARAM lParam);
 
-    static void menuAddItem(MenuItem id, const LPSTR text, bool enabled = true);
+    static void menuAddItem(MenuItem id, const LPCSTR text, bool enabled = true);
     static void menuAddSeperator();
     static bool menuGetItemChecked(MenuItem id);
     static void menuSetItemChecked(MenuItem id, bool checked);

--- a/server/src/utils/endian.hpp
+++ b/server/src/utils/endian.hpp
@@ -24,7 +24,14 @@
 #define TRAINTASTIC_SERVER_UTILS_ENDIAN_HPP
 
 #include <type_traits>
-#ifdef _MSC_VER
+
+
+#if defined(__MINGW32__) || defined(__MINGW64__)
+//Needed for definition of _byteswap_ushort, _byteswap_ulong and _byteswap_uint64 on MinGW
+#include <cstdlib>
+#endif
+
+#if defined(_MSC_VER) || defined(__MINGW32__) || defined(__MINGW64__)
   #define bswap_16(x) _byteswap_ushort(x)
   #define bswap_32(x) _byteswap_ulong(x)
   #define bswap_64(x) _byteswap_uint64(x)

--- a/server/src/utils/setthreadname.cpp
+++ b/server/src/utils/setthreadname.cpp
@@ -42,7 +42,7 @@ void setThreadName(const char* name)
     pthread_setname_np(pthread_self(), name);
   #endif
 #endif
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW32__) && !defined(__MINGW64__)
   if constexpr(std::is_same_v<std::thread::native_handle_type, HANDLE>)
   {
     const size_t nameSize = strlen(name);


### PR DESCRIPTION
Hello,
This program seems very interesting!
I really like the code style, especially the `InterfaceItem` system which I will study further in the next weeks.

I use MinGW compiler (bundled with Qt package) but in order to build `traintastic-server`, a few fix must be done.
These changes shouldn't affect other systems/compilers because they are all guarded inside `#ifdef`/`#endif`.

Additional changes to the installer would be needed to ship MinGW runtime for MinGW builds.
If you want I can write a separate Pull Request for that.

**NOTE**:
I used **Qt  5.15.2 64-bit** version but the shipped `MinGW (v. 8.1.0)` has a bug in `std::filesystem` header.
To fix the issue I used the newer version `MinGW 11.2.0` (shipped with Qt 6).
When using tools like `windeployqt` pay attention to put the updated version of `libstdc++6.dll` inside program folder.

Please let me know your thoughts on this matter.
Filippo