### PR TITLE
input: fix TraintasticDIY input simulation

### DIFF
--- a/server/src/hardware/protocol/traintasticdiy/kernel.cpp
+++ b/server/src/hardware/protocol/traintasticdiy/kernel.cpp
@@ -374,7 +374,7 @@ void Kernel::simulateInputChange(uint16_t address)
       [this, address]()
       {
         auto it = m_inputValues.find(address);
-        receive(SetInputState(address, (it == m_inputValues.end() && it->second == InputState::True) ? InputState::False : InputState::True));
+        receive(SetInputState(address, (it == m_inputValues.end() || it->second == InputState::True) ? InputState::False : InputState::True));
       });
 }
 


### PR DESCRIPTION
Toggling a disabled input caused crash.
Prevent iterator derefencing when invalid.

Other interfaces, like z21, allow toggling disabled inputs so the behaviour is still correct.