### PR TITLE
Windows Tray: set DPI aware

### DIFF
--- a/server/src/os/windows/trayicon.cpp
+++ b/server/src/os/windows/trayicon.cpp
@@ -29,6 +29,8 @@
 #include "../../traintastic/traintastic.hpp"
 #include "../../utils/setthreadname.hpp"
 
+#include <iostream>
+
 namespace Windows {
 
 std::unique_ptr<std::thread> TrayIcon::s_thread;
@@ -58,6 +60,10 @@ void TrayIcon::run(bool isRestart)
   // register window class, once:
   if(!isRestart)
   {
+    bool val = IsProcessDPIAware();
+    bool val1 = SetProcessDPIAware() == TRUE;
+    std::cout << std::endl << "DPI MENU:" << val << " then " <<  val1 << std::endl << std::endl;
+
     WNDCLASSEX windowClass;
     memset(&windowClass, 0, sizeof(windowClass));
     windowClass.cbSize = sizeof(windowClass);


### PR DESCRIPTION
Prevent blur on Windows High DPI Monitor.
Tested on Windows 10, 1920x1080.

This might drop support for older version on Windows (like XP)
[Microsoft Docs](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setprocessdpiaware) suggest to add a manifest file to the executable instead of manually calling this function.
Qt 5.15 already doesn't support Windows XP so client cannot run on it but server could.
Maybe by adding a manifest file instead of calling this function, older Windows version might just ignore the value and run normally.