### PR TITLE
Add MinGW section to BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -49,6 +49,12 @@ This must be done AFTER inferior has started, symbol loading is delayed until fi
 
 More info in [GDB Documentation](https://sourceware.org/gdb/onlinedocs/gdb/Files.html)
 
+#### Client only
+
+Qt debugging symbols are distributed separately in `NAME.dll.debug` files.
+These files needs to be copied in same directory of the deployed DLL so GDB automatically loads them.
+They usually are in `C:\Qt\5.15.2\mingw81_64\lib`
+
 ### Linux
 
 In the *build* directory:

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -25,7 +25,29 @@ In the *build* directory:
 
 ### Windows (MinGW)
 
-*TODO*
+> NOTE: GCC 8.1 has a bug in `<filesystem>` standard header which prevents compilation
+To avoid build errors update to a newer version, e.g. MinGW 11.2.0
+
+In the *build* directory:
+- Configure CMake: `cmake ../ -G "MinGW Makefiles" -A x64 -DCMAKE_BUILD_TYPE=Release`
+- Build traintastic-client: `cmake --build . --config Release`
+
+#### Debug builds (Client and Server)
+
+For *Debug* builds use `-DCMAKE_BUILD_TYPE=Debug`
+Turning off some optimizations might help debugging when stepping inside source code. Set `CMAKE_CXX_FLAGS_DEBUG="-g -Og"`
+
+GDB takes a lot to start debugging because both client and server load many DLL on Windows.
+To mitigate that turn off auto loading of shared library symbols BEFORE starting the inferior with GDB command:
+
+`set auto-solib-add off`
+
+If you need to step into some library code (for example Qt libraries in Client) you can load a library by running GDB command:
+
+`sharedlibrary LIBRARY_NAME`
+This must be done AFTER inferior has started, symbol loading is delayed until fisrt breakpoint is hit or at `break` command
+
+More info in [GDB Documentation](https://sourceware.org/gdb/onlinedocs/gdb/Files.html)
 
 ### Linux
 
@@ -66,7 +88,14 @@ In the *build* directory:
 
 ### Windows (MinGW)
 
-*TODO*
+> NOTE: GCC 8.1 has a bug in `<filesystem>` standard header which prevents compilation
+To avoid build errors update to a newer version, e.g. MinGW 11.2.0
+
+In the *build* directory:
+- Configure CMake: `cmake ../ -G "MinGW Makefiles" -A x64 -DCMAKE_BUILD_TYPE=Release`
+- Build traintastic-client: `cmake --build . --config Release`
+
+For *Debug builds* see Client section of MinGW
 
 ### Linux
 


### PR DESCRIPTION
Added instructions specific to MinGW.
Linked GDB online documentation.

I must say I don't like the document layout because instructions are duplicated almost same for Client and Server.
But that's a minor thing.

I added information about debugging which are entirely missing for other setups.
Maybe something should be added for them too, and something is common to many compilers