### PR TITLE
model: HACK to let client refresh after object is removed

### DIFF
--- a/server/src/core/objectlist.hpp
+++ b/server/src/core/objectlist.hpp
@@ -153,6 +153,12 @@ class ObjectList : public AbstractObjectList
         m_propertyChanged.erase(object.get());
         m_items.erase(it);
         rowCountChanged();
+
+        uint32_t row = std::distance(m_items.begin(), it);
+        for(auto& model : m_models)
+        {
+          model->rowRemovedHack(row);
+        }
       }
     }
 };

--- a/server/src/core/tablemodel.cpp
+++ b/server/src/core/tablemodel.cpp
@@ -53,6 +53,17 @@ void TableModel::setRegion(const Region& value)
   }
 }
 
+void TableModel::rowRemovedHack(uint32_t row)
+{
+  //Hack, tell clients to refresh from row onwards
+  Region update = m_region;
+  if(update.rowMin <= row && update.rowMax >= row)
+  {
+    update.rowMin = row;
+    updateRegion(shared_ptr<TableModel>(), update);
+  }
+}
+
 void TableModel::setColumnHeaders(std::vector<std::string_view> values)
 {
   m_columnHeaders = std::move(values);

--- a/server/src/core/tablemodel.hpp
+++ b/server/src/core/tablemodel.hpp
@@ -110,6 +110,8 @@ class TableModel : public Object
     virtual std::string getText(uint32_t column, uint32_t row) const = 0;
 
     void setRegion(const Region& value);
+
+    void rowRemovedHack(uint32_t row);
 };
 
 #endif


### PR DESCRIPTION
When an object is removed from a list, Clients need to clear cached values and reload the model.
This could be more efficient but it will be adressed in a separate pull request.

We can open a new issue specific to Client side sorting and caching