### PR TITLE
Logger workaround for MinGW broken std::put_time()

### DIFF
--- a/server/src/log/consolelogger.cpp
+++ b/server/src/log/consolelogger.cpp
@@ -41,11 +41,13 @@ void ConsoleLogger::write(const std::chrono::system_clock::time_point& time, std
   const auto us = std::chrono::duration_cast<std::chrono::microseconds>(time.time_since_epoch()) % 1000000;
   tm tm;
 
+  const char time_format[] = TRAINTASTIC_LOG_DATE_FORMAT " " TRAINTASTIC_LOG_TIME_FORMAT;
+
   std::lock_guard<std::mutex> lock(m_streamMutex);
 
   std::ostream& ss = (isErrorLogMessage(code) || isCriticalLogMessage(code) || isFatalLogMessage(code)) ? std::cerr : std::cout;
   ss
-    << std::put_time(localTime(&systemTime, &tm), "%F %T") << '.' << std::setfill('0') << std::setw(6) << us.count() << ' '
+    << std::put_time(localTime(&systemTime, &tm), time_format) << '.' << std::setfill('0') << std::setw(6) << us.count() << ' '
     << objectId << ' '
     << logMessageChar(code) << std::setw(4) << logMessageNumber(code) << ": "
     << message

--- a/server/src/log/filelogger.cpp
+++ b/server/src/log/filelogger.cpp
@@ -55,8 +55,10 @@ void FileLogger::write(const std::chrono::system_clock::time_point& time, std::s
 
   std::lock_guard<std::mutex> lock(m_fileMutex);
 
+  const char time_format[] = TRAINTASTIC_LOG_DATE_FORMAT ";" TRAINTASTIC_LOG_TIME_FORMAT;
+
   m_file
-    << std::put_time(localTime(&systemTime, &tm), "%F;%T") << '.' << std::setfill('0') << std::setw(6) << us.count() << ';'
+    << std::put_time(localTime(&systemTime, &tm), time_format) << '.' << std::setfill('0') << std::setw(6) << us.count() << ';'
     << objectId << ';'
     << logMessageChar(code) << std::setw(4) << logMessageNumber(code) << ';'
     << message

--- a/server/src/log/logger.hpp
+++ b/server/src/log/logger.hpp
@@ -29,6 +29,16 @@
 #include <chrono>
 #include <traintastic/enum/logmessage.hpp>
 
+#if defined(__MINGW32__) || defined(__MINGW64__)
+//NOTE: MinGW does not yet support all C++11 std::put_time specifiers
+//See bug: https://sourceforge.net/p/mingw-w64/bugs/793
+#define TRAINTASTIC_LOG_DATE_FORMAT "%Y-%m-%d"
+#define TRAINTASTIC_LOG_TIME_FORMAT "%H:%M:%S"
+#else
+#define TRAINTASTIC_LOG_DATE_FORMAT "%F"
+#define TRAINTASTIC_LOG_TIME_FORMAT "%T"
+#endif
+
 class Logger
 {
   protected:


### PR DESCRIPTION
- Conform ConsoleLogger and FileLogger to use same format in 'std::put_time()'

- Workaround missing specifier support in MinGW 12.2.0 by using old pre-C+ +11 specifiers.

See #35