### PR TITLE
Add 4 new positions to Double Slip Switch turnout

### DIFF
--- a/client/src/board/tilepainter.cpp
+++ b/client/src/board/tilepainter.cpp
@@ -486,6 +486,14 @@ void TilePainter::drawTurnout(TileId id, const QRectF& r, TileRotate rotate, Tur
       setTurnoutStatePen();
       switch(position)
       {
+        case TurnoutPosition::Left:
+          drawCurve45(turnoutStateRect(r), rotate);
+          break;
+
+        case TurnoutPosition::Right:
+          drawCurve45(turnoutStateRect(r), rotate + TileRotate::Deg180);
+          break;
+
         case TurnoutPosition::Crossed:
           drawStraight(turnoutStateRect(r), rotate);
           drawStraight(turnoutStateRect(r), rotate - TileRotate::Deg45);
@@ -494,6 +502,14 @@ void TilePainter::drawTurnout(TileId id, const QRectF& r, TileRotate rotate, Tur
         case TurnoutPosition::Diverged:
           drawCurve45(turnoutStateRect(r), rotate);
           drawCurve45(turnoutStateRect(r), rotate + TileRotate::Deg180);
+          break;
+
+        case TurnoutPosition::DoubleSlipStraightA:
+          drawStraight(turnoutStateRect(r), rotate);
+          break;
+
+        case TurnoutPosition::DoubleSlipStraightB:
+          drawStraight(turnoutStateRect(r), rotate - TileRotate::Deg45);
           break;
 
         default:

--- a/client/src/board/tilepainter.cpp
+++ b/client/src/board/tilepainter.cpp
@@ -471,6 +471,14 @@ void TilePainter::drawTurnout(TileId id, const QRectF& r, TileRotate rotate, Tur
           drawCurve45(turnoutStateRect(r), rotate);
           break;
 
+        case TurnoutPosition::DoubleSlipStraightA:
+          drawStraight(turnoutStateRect(r), rotate);
+          break;
+
+        case TurnoutPosition::DoubleSlipStraightB:
+          drawStraight(turnoutStateRect(r), rotate - TileRotate::Deg45);
+          break;
+
         default:
           break;
       }

--- a/server/src/board/map/signalpath.cpp
+++ b/server/src/board/map/signalpath.cpp
@@ -190,23 +190,41 @@ std::unique_ptr<const SignalPath::Item> SignalPath::findBlocks(const Node& node,
         {
           next.emplace(TurnoutPosition::Crossed, findBlocks(nextNode, nextNode.getLink(2), blocksAhead));
           next.emplace(TurnoutPosition::Diverged, findBlocks(nextNode, nextNode.getLink(1), blocksAhead));
+          if(turnout->tileId() == TileId::RailTurnoutDoubleSlip)
+          {
+            next.emplace(TurnoutPosition::DoubleSlipStraightA, findBlocks(nextNode, nextNode.getLink(2), blocksAhead));
+            next.emplace(TurnoutPosition::Left, findBlocks(nextNode, nextNode.getLink(1), blocksAhead));
+          }
         }
         else if(nextNode.getLink(1).get() == &link)
         {
           next.emplace(TurnoutPosition::Crossed, findBlocks(nextNode, nextNode.getLink(3), blocksAhead));
           next.emplace(TurnoutPosition::Diverged, findBlocks(nextNode, nextNode.getLink(0), blocksAhead));
+          if(turnout->tileId() == TileId::RailTurnoutDoubleSlip)
+          {
+            next.emplace(TurnoutPosition::DoubleSlipStraightB, findBlocks(nextNode, nextNode.getLink(3), blocksAhead));
+            next.emplace(TurnoutPosition::Left, findBlocks(nextNode, nextNode.getLink(0), blocksAhead));
+          }
         }
         else if(nextNode.getLink(2).get() == &link)
         {
           next.emplace(TurnoutPosition::Crossed, findBlocks(nextNode, nextNode.getLink(0), blocksAhead));
           if(turnout->tileId() == TileId::RailTurnoutDoubleSlip)
+          {
             next.emplace(TurnoutPosition::Diverged, findBlocks(nextNode, nextNode.getLink(3), blocksAhead));
+            next.emplace(TurnoutPosition::DoubleSlipStraightA, findBlocks(nextNode, nextNode.getLink(0), blocksAhead));
+            next.emplace(TurnoutPosition::Right, findBlocks(nextNode, nextNode.getLink(3), blocksAhead));
+          }
         }
         else if(nextNode.getLink(3).get() == &link)
         {
           next.emplace(TurnoutPosition::Crossed, findBlocks(nextNode, nextNode.getLink(1), blocksAhead));
           if(turnout->tileId() == TileId::RailTurnoutDoubleSlip)
+          {
             next.emplace(TurnoutPosition::Diverged, findBlocks(nextNode, nextNode.getLink(2), blocksAhead));
+            next.emplace(TurnoutPosition::DoubleSlipStraightB, findBlocks(nextNode, nextNode.getLink(1), blocksAhead));
+            next.emplace(TurnoutPosition::Right, findBlocks(nextNode, nextNode.getLink(2), blocksAhead));
+          }
         }
         else
         {

--- a/server/src/board/map/signalpath.cpp
+++ b/server/src/board/map/signalpath.cpp
@@ -190,9 +190,9 @@ std::unique_ptr<const SignalPath::Item> SignalPath::findBlocks(const Node& node,
         {
           next.emplace(TurnoutPosition::Crossed, findBlocks(nextNode, nextNode.getLink(2), blocksAhead));
           next.emplace(TurnoutPosition::Diverged, findBlocks(nextNode, nextNode.getLink(1), blocksAhead));
+          next.emplace(TurnoutPosition::DoubleSlipStraightA, findBlocks(nextNode, nextNode.getLink(2), blocksAhead));
           if(turnout->tileId() == TileId::RailTurnoutDoubleSlip)
           {
-            next.emplace(TurnoutPosition::DoubleSlipStraightA, findBlocks(nextNode, nextNode.getLink(2), blocksAhead));
             next.emplace(TurnoutPosition::Left, findBlocks(nextNode, nextNode.getLink(1), blocksAhead));
           }
         }
@@ -200,29 +200,29 @@ std::unique_ptr<const SignalPath::Item> SignalPath::findBlocks(const Node& node,
         {
           next.emplace(TurnoutPosition::Crossed, findBlocks(nextNode, nextNode.getLink(3), blocksAhead));
           next.emplace(TurnoutPosition::Diverged, findBlocks(nextNode, nextNode.getLink(0), blocksAhead));
+          next.emplace(TurnoutPosition::DoubleSlipStraightB, findBlocks(nextNode, nextNode.getLink(3), blocksAhead));
           if(turnout->tileId() == TileId::RailTurnoutDoubleSlip)
           {
-            next.emplace(TurnoutPosition::DoubleSlipStraightB, findBlocks(nextNode, nextNode.getLink(3), blocksAhead));
             next.emplace(TurnoutPosition::Left, findBlocks(nextNode, nextNode.getLink(0), blocksAhead));
           }
         }
         else if(nextNode.getLink(2).get() == &link)
         {
           next.emplace(TurnoutPosition::Crossed, findBlocks(nextNode, nextNode.getLink(0), blocksAhead));
+          next.emplace(TurnoutPosition::DoubleSlipStraightA, findBlocks(nextNode, nextNode.getLink(0), blocksAhead));
           if(turnout->tileId() == TileId::RailTurnoutDoubleSlip)
           {
             next.emplace(TurnoutPosition::Diverged, findBlocks(nextNode, nextNode.getLink(3), blocksAhead));
-            next.emplace(TurnoutPosition::DoubleSlipStraightA, findBlocks(nextNode, nextNode.getLink(0), blocksAhead));
             next.emplace(TurnoutPosition::Right, findBlocks(nextNode, nextNode.getLink(3), blocksAhead));
           }
         }
         else if(nextNode.getLink(3).get() == &link)
         {
           next.emplace(TurnoutPosition::Crossed, findBlocks(nextNode, nextNode.getLink(1), blocksAhead));
+          next.emplace(TurnoutPosition::DoubleSlipStraightB, findBlocks(nextNode, nextNode.getLink(1), blocksAhead));
           if(turnout->tileId() == TileId::RailTurnoutDoubleSlip)
           {
             next.emplace(TurnoutPosition::Diverged, findBlocks(nextNode, nextNode.getLink(2), blocksAhead));
-            next.emplace(TurnoutPosition::DoubleSlipStraightB, findBlocks(nextNode, nextNode.getLink(1), blocksAhead));
             next.emplace(TurnoutPosition::Right, findBlocks(nextNode, nextNode.getLink(2), blocksAhead));
           }
         }

--- a/server/src/board/tile/rail/turnout/turnoutdoublesliprailtile.cpp
+++ b/server/src/board/tile/rail/turnout/turnoutdoublesliprailtile.cpp
@@ -23,13 +23,22 @@
 #include "turnoutdoublesliprailtile.hpp"
 #include "../../../../core/attributes.hpp"
 
-static const std::array<TurnoutPosition, 3> positionValues = {TurnoutPosition::Crossed, TurnoutPosition::Diverged, TurnoutPosition::Unknown};
-static const std::array<TurnoutPosition, 2> setPositionValues = {TurnoutPosition::Crossed, TurnoutPosition::Diverged};
+static const std::array<TurnoutPosition, 7> positionValues = {TurnoutPosition::Left, TurnoutPosition::Right,
+                                                              TurnoutPosition::Crossed, TurnoutPosition::Diverged,
+                                                              TurnoutPosition::DoubleSlipStraightA, TurnoutPosition::DoubleSlipStraightB,
+                                                              TurnoutPosition::Unknown};
+static const std::array<TurnoutPosition, 6> setPositionValues = {TurnoutPosition::Left, TurnoutPosition::Right,
+                                                                 TurnoutPosition::Crossed, TurnoutPosition::Diverged,
+                                                                 TurnoutPosition::DoubleSlipStraightA, TurnoutPosition::DoubleSlipStraightB};
 
 TurnoutDoubleSlipRailTile::TurnoutDoubleSlipRailTile(World& world, std::string_view _id)
   : TurnoutRailTile(world, _id, TileId::RailTurnoutDoubleSlip, 4)
 {
-  outputMap.setValueInternal(std::make_shared<TurnoutOutputMap>(*this, outputMap.name(), std::initializer_list<TurnoutPosition>{TurnoutPosition::Crossed, TurnoutPosition::Diverged}));
+  outputMap.setValueInternal(std::make_shared<TurnoutOutputMap>(*this, outputMap.name(),
+                                                                std::initializer_list<TurnoutPosition>{
+                                                                    TurnoutPosition::Left, TurnoutPosition::Right,
+                                                                    TurnoutPosition::Crossed, TurnoutPosition::Diverged,
+                                                                    TurnoutPosition::DoubleSlipStraightA, TurnoutPosition::DoubleSlipStraightB}));
 
   Attributes::addValues(position, positionValues);
   m_interfaceItems.add(position);

--- a/server/src/board/tile/rail/turnout/turnoutsinglesliprailtile.cpp
+++ b/server/src/board/tile/rail/turnout/turnoutsinglesliprailtile.cpp
@@ -23,13 +23,19 @@
 #include "turnoutsinglesliprailtile.hpp"
 #include "../../../../core/attributes.hpp"
 
-static const std::array<TurnoutPosition, 3> positionValues = {TurnoutPosition::Crossed, TurnoutPosition::Diverged, TurnoutPosition::Unknown};
-static const std::array<TurnoutPosition, 2> setPositionValues = {TurnoutPosition::Crossed, TurnoutPosition::Diverged};
+static const std::array<TurnoutPosition, 5> positionValues = {TurnoutPosition::Crossed, TurnoutPosition::Diverged,
+                                                              TurnoutPosition::DoubleSlipStraightA, TurnoutPosition::DoubleSlipStraightB,
+                                                              TurnoutPosition::Unknown};
+static const std::array<TurnoutPosition, 4> setPositionValues = {TurnoutPosition::Crossed, TurnoutPosition::Diverged,
+                                                                 TurnoutPosition::DoubleSlipStraightA, TurnoutPosition::DoubleSlipStraightB};
 
 TurnoutSingleSlipRailTile::TurnoutSingleSlipRailTile(World& world, std::string_view _id)
   : TurnoutRailTile(world, _id, TileId::RailTurnoutSingleSlip, 4)
 {
-  outputMap.setValueInternal(std::make_shared<TurnoutOutputMap>(*this, outputMap.name(), std::initializer_list<TurnoutPosition>{TurnoutPosition::Crossed, TurnoutPosition::Diverged}));
+  outputMap.setValueInternal(std::make_shared<TurnoutOutputMap>(*this, outputMap.name(),
+                                                                  std::initializer_list<TurnoutPosition>{
+                                                                    TurnoutPosition::Crossed, TurnoutPosition::Diverged,
+                                                                    TurnoutPosition::DoubleSlipStraightA, TurnoutPosition::DoubleSlipStraightB}));
 
   Attributes::addValues(position, positionValues);
   m_interfaceItems.add(position);

--- a/shared/src/traintastic/enum/turnoutposition.hpp
+++ b/shared/src/traintastic/enum/turnoutposition.hpp
@@ -34,16 +34,20 @@ enum class TurnoutPosition : uint8_t
   Right = 3,
   Crossed = 4,
   Diverged = 5,
+  DoubleSlipStraightA = 6,
+  DoubleSlipStraightB = 7
 };
 
-TRAINTASTIC_ENUM(TurnoutPosition, "turnout_position", 6,
+TRAINTASTIC_ENUM(TurnoutPosition, "turnout_position", 8,
 {
   {TurnoutPosition::Unknown, "unknown"},
   {TurnoutPosition::Straight, "straight"},
   {TurnoutPosition::Left, "left"},
   {TurnoutPosition::Right, "right"},
   {TurnoutPosition::Crossed, "crossed"},
-  {TurnoutPosition::Diverged, "diverged"}
+  {TurnoutPosition::Diverged, "diverged"},
+  {TurnoutPosition::DoubleSlipStraightA, "double_slip_straight_a"},
+  {TurnoutPosition::DoubleSlipStraightB, "double_slip_straight_b"}
 });
 
 #endif


### PR DESCRIPTION
- This adds Left/Right to double switch
- And adds new DoubleSlipStraightA / DoubleSlipStraightB to TurnoutPosition enum
- Implemented new state drawing in TilePainter
- Updated logic in SignalPath::findBlocks()

Hi, this PR implements features of #15.
It's a quick test so might break code style but the logic seems fine.
Maybe the names of new states should be changed...
Also it would be good to initialize `outputMap.setValueInternal()` with `positionValues` array to avoid duplicating the list.

Closes #15