### PR TITLE
Fix train vehicle list

### DIFF
--- a/client/src/widget/objectlist/objectlistwidget.cpp
+++ b/client/src/widget/objectlist/objectlistwidget.cpp
@@ -228,46 +228,35 @@ ObjectListWidget::ObjectListWidget(const ObjectPtr& object, QWidget* parent) :
 
   if(Method* move = m_object->getMethod("move"))
   {
-    m_actionMoveUp = new QAction(Theme::getIcon("up"), Locale::tr("list:move_up"), this);
-    connect(m_actionMoveUp, &QAction::triggered, this,
-      [this, move]()
+    m_actionMoveUp = new MethodAction(Theme::getIcon("up"), *move,
+      [this]()
       {
         if(auto* model = m_tableWidget->selectionModel(); model && model->hasSelection())
         {
           if(const auto rows = model->selectedRows(); !rows.empty())
           {
             const int row = rows[0].row();
-            callMethod(*move, nullptr, row, row - 1);
+            callMethod(m_actionMoveUp->method(), nullptr, row, row - 1);
             m_tableWidget->selectRow(row - 1);
           }
         }
       });
+    m_actionMoveUp->setForceDisabled(true);
 
-    m_actionMoveDown = new QAction(Theme::getIcon("down"), Locale::tr("list:move_down"), this);
-    connect(m_actionMoveDown, &QAction::triggered, this,
-      [this, move]()
+    m_actionMoveDown = new MethodAction(Theme::getIcon("down"), *move,
+      [this]()
       {
         if(auto* model = m_tableWidget->selectionModel(); model && model->hasSelection())
         {
           if(const auto rows = model->selectedRows(); !rows.empty())
           {
             const int row = rows[0].row();
-            callMethod(*move, nullptr, row, row + 1);
+            callMethod(m_actionMoveDown->method(), nullptr, row, row + 1);
             m_tableWidget->selectRow(row + 1);
           }
         }
       });
-
-    connect(move, &Method::attributeChanged, this,
-      [this](AttributeName name, const QVariant& value)
-      {
-        if(name == AttributeName::Enabled)
-        {
-          const bool b = value.toBool();
-          m_actionMoveUp->setEnabled(b);
-          m_actionMoveDown->setEnabled(b);
-        }
-      });
+    m_actionMoveDown->setForceDisabled(true);
   }
 
   if(Method* method = m_object->getMethod("reverse"))
@@ -485,8 +474,8 @@ void ObjectListWidget::tableSelectionChanged(bool hasSelection)
   {
     const int selectedRow = m_tableWidget->selectionModel() && m_tableWidget->selectionModel()->selectedRows().length() == 1 ? m_tableWidget->selectionModel()->selectedRows()[0].row() : -1;
     if(m_actionMoveUp)
-      m_actionMoveUp->setEnabled(hasSelection && selectedRow != 0);
+      m_actionMoveUp->setForceDisabled(!hasSelection || selectedRow == 0);
     if(m_actionMoveDown)
-      m_actionMoveDown->setEnabled(hasSelection && selectedRow != (m_tableWidget->model()->rowCount() - 1));
+      m_actionMoveDown->setForceDisabled(!hasSelection || selectedRow == (m_tableWidget->model()->rowCount() - 1));
   }
 }

--- a/client/src/widget/objectlist/objectlistwidget.cpp
+++ b/client/src/widget/objectlist/objectlistwidget.cpp
@@ -294,7 +294,7 @@ ObjectListWidget::ObjectListWidget(const ObjectPtr& object, QWidget* parent) :
         else
           text = value.toString();
 
-        menu->addAction(text,
+        menu->addAction(text, this,
           [this, channel=value.toUInt()]()
           {
             //cancelRequest(m_requestIdInputMonitor);
@@ -348,7 +348,7 @@ ObjectListWidget::ObjectListWidget(const ObjectPtr& object, QWidget* parent) :
         else
           text = value.toString();
 
-        menu->addAction(text,
+        menu->addAction(text, this,
           [this, channel=value.toUInt()]()
           {
             //cancelRequest(m_requestIdOutputKeyboard);

--- a/client/src/widget/objectlist/objectlistwidget.cpp
+++ b/client/src/widget/objectlist/objectlistwidget.cpp
@@ -241,6 +241,8 @@ ObjectListWidget::ObjectListWidget(const ObjectPtr& object, QWidget* parent) :
           }
         }
       });
+    //Override default method name
+    m_actionMoveUp->setText(Locale::tr("list:move_up"));
     m_actionMoveUp->setForceDisabled(true);
 
     m_actionMoveDown = new MethodAction(Theme::getIcon("down"), *move,
@@ -256,6 +258,8 @@ ObjectListWidget::ObjectListWidget(const ObjectPtr& object, QWidget* parent) :
           }
         }
       });
+    //Override default method name
+    m_actionMoveDown->setText(Locale::tr("list:move_down"));
     m_actionMoveDown->setForceDisabled(true);
   }
 

--- a/client/src/widget/objectlist/objectlistwidget.hpp
+++ b/client/src/widget/objectlist/objectlistwidget.hpp
@@ -48,8 +48,8 @@ class ObjectListWidget : public QWidget
     QAction* m_actionEdit;
     MethodAction* m_actionRemove = nullptr;
     MethodAction* m_actionDelete;
-    QAction* m_actionMoveUp = nullptr;
-    QAction* m_actionMoveDown = nullptr;
+    MethodAction* m_actionMoveUp = nullptr;
+    MethodAction* m_actionMoveDown = nullptr;
     MethodAction* m_actionReverse = nullptr;
     MethodAction* m_actionInputMonitor;
     MethodAction* m_actionInputMonitorChannel;

--- a/server/src/train/train.cpp
+++ b/server/src/train/train.cpp
@@ -149,9 +149,7 @@ void Train::worldEvent(WorldState state, WorldEvent event)
 {
   IdObject::worldEvent(state, event);
 
-  const bool editable = contains(state, WorldState::Edit);
-
-  Attributes::setEnabled(name, editable);
+  updateEnabled();
 }
 
 void Train::setSpeed(const double kmph)
@@ -273,7 +271,9 @@ void Train::updateEnabled()
 {
   const bool stopped = almostZero(speed.value()) && almostZero(throttleSpeed.value());
 
-  Attributes::setEnabled(name, stopped);
+  const bool editable = contains(m_world.state, WorldState::Edit);
+
+  Attributes::setEnabled(name, stopped && editable);
   Attributes::setEnabled(direction, stopped && powered);
   Attributes::setEnabled(throttleSpeed, powered);
   Attributes::setEnabled(vehicles->add, stopped);


### PR DESCRIPTION
This fixes move Up/Down not disabled when train is moving.

In the second commit I've fixed a clang warning not strictly related to this issue, maybe there are more of them in other places.