### PR TITLE
server: Z21 fix bradcast flags and other small fixes

### DIFF
--- a/server/src/hardware/protocol/z21/clientkernel.cpp
+++ b/server/src/hardware/protocol/z21/clientkernel.cpp
@@ -68,7 +68,7 @@ void ClientKernel::receive(const Message& message)
 
       switch(lanX.xheader)
       {
-        case 0x61:
+        case LAN_X_BC:
           if(message == LanXBCTrackPowerOff() || message == LanXBCTrackShortCircuit())
           {
             if(m_trackPowerOn != TriState::False)
@@ -99,7 +99,7 @@ void ClientKernel::receive(const Message& message)
           }
           break;
 
-        case 0x81:
+        case LAN_X_BC_STOPPED:
           if(message == LanXBCStopped())
           {
             if(m_emergencyStop != TriState::True)

--- a/server/src/hardware/protocol/z21/clientkernel.hpp
+++ b/server/src/hardware/protocol/z21/clientkernel.hpp
@@ -62,6 +62,14 @@ class ClientKernel final : public Kernel
   private:
     const bool m_simulation;
     boost::asio::steady_timer m_keepAliveTimer;
+    BroadcastFlags m_broadcastFlags;
+
+    static constexpr BroadcastFlags requiredBroadcastFlags =
+      BroadcastFlags::PowerLocoTurnoutChanges |
+      BroadcastFlags::RBusChanges |
+      BroadcastFlags::SystemStatusChanges |
+      BroadcastFlags::AllLocoChanges | // seems not to work with DR5000
+      BroadcastFlags::LocoNetDetector;
 
     uint32_t m_serialNumber;
     std::function<void(uint32_t)> m_onSerialNumberChanged;

--- a/server/src/hardware/protocol/z21/clientkernel.hpp
+++ b/server/src/hardware/protocol/z21/clientkernel.hpp
@@ -63,6 +63,8 @@ class ClientKernel final : public Kernel
     const bool m_simulation;
     boost::asio::steady_timer m_keepAliveTimer;
     BroadcastFlags m_broadcastFlags;
+    int m_broadcastFlagsRetryCount;
+    static constexpr int maxBroadcastFlagsRetryCount = 10;
 
     static constexpr BroadcastFlags requiredBroadcastFlags =
       BroadcastFlags::PowerLocoTurnoutChanges |

--- a/server/src/hardware/protocol/z21/clientkernel.hpp
+++ b/server/src/hardware/protocol/z21/clientkernel.hpp
@@ -25,7 +25,7 @@
 
 #include "kernel.hpp"
 #include <boost/asio/steady_timer.hpp>
-#include "../../../enum/tristate.hpp"
+#include <traintastic/enum/tristate.hpp>
 
 enum class SimulateInputAction;
 class InputController;

--- a/server/src/hardware/protocol/z21/iohandler/simulationiohandler.cpp
+++ b/server/src/hardware/protocol/z21/iohandler/simulationiohandler.cpp
@@ -86,7 +86,7 @@ bool SimulationIOHandler::send(const Message& message)
           }
           break;
 
-        case 0x80:
+        case LAN_X_SET_STOP:
           if(message == LanXSetStop())
           {
             const bool changed = !m_emergencyStop;

--- a/server/src/hardware/protocol/z21/kernel.hpp
+++ b/server/src/hardware/protocol/z21/kernel.hpp
@@ -27,7 +27,6 @@
 #include <thread>
 #include <boost/asio/io_context.hpp>
 
-#include <traintastic/enum/tristate.hpp>
 #include "config.hpp"
 #include "iohandler/iohandler.hpp"
 

--- a/server/src/hardware/protocol/z21/messages.cpp
+++ b/server/src/hardware/protocol/z21/messages.cpp
@@ -132,6 +132,13 @@ std::string toString(const Message& message, bool raw)
             raw = true;
           break;
 
+        case LAN_X_BC_STOPPED:
+          if(message == LanXBCStopped())
+            s = "LAN_X_BC_STOPPED";
+          else
+            raw = true;
+          break;
+
         case 0xE3:
           if(const auto& getLocoInfo = static_cast<const LanXGetLocoInfo&>(message); getLocoInfo.db0 == 0xF0)
           {

--- a/server/src/hardware/protocol/z21/messages.cpp
+++ b/server/src/hardware/protocol/z21/messages.cpp
@@ -90,13 +90,6 @@ std::string toString(const Message& message, bool raw)
             raw = true;
           break;
 
-        case 0x43:
-        {
-          const auto& getTurnoutInfo = static_cast<const LanXGetTurnoutInfo&>(message);
-          s = "LAN_X_GET_TURNOUT_INFO";
-          s.append(" address=").append(std::to_string(getTurnoutInfo.address()));
-          break;
-        }
         case 0x53:
         {
           const auto& setTurnout = static_cast<const LanXSetTurnout&>(message);
@@ -108,11 +101,13 @@ std::string toString(const Message& message, bool raw)
           s.append(" queue=").append(setTurnout.queue() ? "yes" : "no");
           break;
         }
-        case 0x61:
+        case LAN_X_BC:
           if(message == LanXBCTrackPowerOff())
             s = "LAN_X_BC_TRACK_POWER_OFF";
           else if(message == LanXBCTrackPowerOn())
             s = "LAN_X_BC_TRACK_POWER_ON";
+          else if(message == LanXBCTrackShortCircuit())
+            s = "LAN_X_BC_TRACK_SHORT_CIRCUIT";
           else
             raw = true;
           break;
@@ -130,7 +125,7 @@ std::string toString(const Message& message, bool raw)
             raw = true;
           break;
 
-        case 0x80:
+        case LAN_X_SET_STOP:
           if(message == LanXSetStop())
             s = "LAN_X_SET_STOP";
           else
@@ -221,7 +216,13 @@ std::string toString(const Message& message, bool raw)
       break;
 
     case LAN_GET_BROADCASTFLAGS:
-      if(message == LanGetBroadcastFlags())
+      if(message.dataLen() == sizeof(LanGetBroadcastFlagsReply))
+      {
+        const auto& reply = static_cast<const LanGetBroadcastFlagsReply&>(message);
+        s = "LAN_GET_BROADCASTFLAGS (Reply)";
+        s.append(" flags=0x").append(toHex(static_cast<std::underlying_type_t<BroadcastFlags>>(reply.broadcastFlags())));
+      }
+      else if(message == LanGetBroadcastFlags())
         s = "LAN_GET_BROADCASTFLAGS";
       else
         raw = true;
@@ -281,7 +282,7 @@ LanXLocoInfo::LanXLocoInfo(const Decoder& decoder) :
     setEmergencyStop();
   else
     setSpeedStep(Decoder::throttleToSpeedStep(decoder.throttle, speedSteps()));
-  for(auto function : *decoder.functions)
+  for(const auto &function : *decoder.functions)
     setFunction(function->number, function->value);
   calcChecksum();
 }

--- a/server/src/hardware/protocol/z21/messages.hpp
+++ b/server/src/hardware/protocol/z21/messages.hpp
@@ -143,7 +143,7 @@ enum LocoMode : uint8_t
 };
 
 static constexpr uint8_t LAN_X_SET_STOP = 0x80;
-//static constexpr uint8_t LAN_X_TURNOUT_INFO = 0x43;
+static constexpr uint8_t LAN_X_TURNOUT_INFO = 0x43;
 static constexpr uint8_t LAN_X_BC = 0x61;
 static constexpr uint8_t LAN_X_BC_TRACK_POWER_OFF = 0x00;
 static constexpr uint8_t LAN_X_BC_TRACK_POWER_ON = 0x01;
@@ -351,7 +351,7 @@ struct LanXGetStatus : LanX
     LanX(sizeof(LanXGetStatus), 0x21)
   {
   }
-};
+} ATTRIBUTE_PACKED;
 static_assert(sizeof(LanXGetStatus) == 7);
 
 // LAN_X_SET_TRACK_POWER_OFF
@@ -398,7 +398,7 @@ struct LanXGetTurnoutInfo : LanX
   uint8_t checksum;
 
   LanXGetTurnoutInfo(uint16_t address)
-    : LanX(sizeof(LanXGetTurnoutInfo), 0x43)
+    : LanX(sizeof(LanXGetTurnoutInfo), LAN_X_TURNOUT_INFO)
     , db0(address >> 8)
     , db1(address & 0xFF)
   {
@@ -769,7 +769,7 @@ struct LanRMBusGetData : Message
     , groupIndex{groupIndex_}
   {
   }
-};
+} ATTRIBUTE_PACKED;
 static_assert(sizeof(LanRMBusGetData) == 5);
 
 // LAN_RMBUS_PROGRAMMODULE
@@ -921,10 +921,12 @@ struct LanXGetVersionReply : LanX
     assert(value < 100);
     xBusVersionBCD = Utils::toBCD(value);
   }
-};
+} ATTRIBUTE_PACKED;
 static_assert(sizeof(LanXGetVersionReply) == 9);
 
 // Reply to LAN_GET_CODE
+
+// LAN_X_GET_FIRMWARE_VERSION
 struct LanXGetFirmwareVersionReply : LanX
 {
   uint8_t db0 = 0x0A;
@@ -966,7 +968,7 @@ struct LanXGetFirmwareVersionReply : LanX
     assert(value < 100);
     minorBCD = Utils::toBCD(value);
   }
-};
+} ATTRIBUTE_PACKED;
 static_assert(sizeof(LanXGetFirmwareVersionReply) == 9);
 
 // Reply to LAN_GET_HWINFO
@@ -1011,7 +1013,7 @@ struct LanXBCTrackPowerOff : LanX
     LanX(sizeof(LanXBCTrackPowerOff), LAN_X_BC)
   {
   }
-};
+} ATTRIBUTE_PACKED;
 static_assert(sizeof(LanXBCTrackPowerOff) == 7);
 
 // LAN_X_BC_TRACK_POWER_ON
@@ -1024,7 +1026,7 @@ struct LanXBCTrackPowerOn : LanX
     LanX(sizeof(LanXBCTrackPowerOn), LAN_X_BC)
   {
   }
-};
+} ATTRIBUTE_PACKED;
 static_assert(sizeof(LanXBCTrackPowerOn) == 7);
 
 // LAN_X_BC_PROGRAMMING_MODE
@@ -1039,7 +1041,7 @@ struct LanXBCTrackShortCircuit : LanX
       LanX(sizeof(LanXBCTrackShortCircuit), LAN_X_BC)
   {
   }
-};
+} ATTRIBUTE_PACKED;
 static_assert(sizeof(LanXBCTrackShortCircuit) == 7);
 
 // LAN_X_CV_NACK_SC
@@ -1059,7 +1061,7 @@ struct LanXStatusChanged : LanX
     LanX(sizeof(LanXStatusChanged), 0x62)
   {
   }
-};
+} ATTRIBUTE_PACKED;
 static_assert(sizeof(LanXStatusChanged) == 8);
 
 // Reply to LAN_X_GET_VERSION
@@ -1076,7 +1078,7 @@ struct LanXBCStopped : LanX
     LanX(sizeof(LanXBCStopped), LAN_X_BC_STOPPED)
   {
   }
-};
+} ATTRIBUTE_PACKED;
 static_assert(sizeof(LanXBCStopped) == 7);
 
 // LAN_X_LOCO_INFO

--- a/server/src/hardware/protocol/z21/messages.hpp
+++ b/server/src/hardware/protocol/z21/messages.hpp
@@ -1072,7 +1072,7 @@ static_assert(sizeof(LanXStatusChanged) == 8);
 struct LanXBCStopped : LanX
 {
   uint8_t db0 = 0x00;
-  uint8_t checksum = 0x80;
+  uint8_t checksum = 0x81;
 
   LanXBCStopped() :
     LanX(sizeof(LanXBCStopped), LAN_X_BC_STOPPED)

--- a/server/src/hardware/protocol/z21/messages.hpp
+++ b/server/src/hardware/protocol/z21/messages.hpp
@@ -1263,6 +1263,22 @@ static_assert(sizeof(LanXLocoInfo) == 14);
 // Reply to LAN_X_GET_FIRMWARE_VERSION
 
 // Reply to LAN_GET_BROADCASTFLAGS
+struct LanGetBroadcastFlagsReply : Message
+{
+  BroadcastFlags broadcastFlagsLE; // LE
+
+  LanGetBroadcastFlagsReply(BroadcastFlags _broadcastFlags = BroadcastFlags::None) :
+      Message(sizeof(LanGetBroadcastFlagsReply), LAN_GET_BROADCASTFLAGS),
+      broadcastFlagsLE{host_to_le(_broadcastFlags)}
+  {
+  }
+
+  inline BroadcastFlags broadcastFlags() const
+  {
+    return le_to_host(broadcastFlagsLE);
+  }
+} ATTRIBUTE_PACKED;
+static_assert(sizeof(LanGetBroadcastFlagsReply) == 8);
 
 // Reply to LAN_GET_LOCOMODE
 struct LanGetLocoModeReply : Message

--- a/server/src/hardware/protocol/z21/serverkernel.cpp
+++ b/server/src/hardware/protocol/z21/serverkernel.cpp
@@ -134,7 +134,7 @@ void ServerKernel::receiveFrom(const Message& message, IOHandler::ClientId clien
           }
           break;
 
-        case 0x80:
+        case LAN_X_SET_STOP:
           if(message == LanXSetStop())
           {
             if(m_config.allowEmergencyStop && m_emergencyStop != TriState::True && m_onEmergencyStop)

--- a/server/src/hardware/protocol/z21/serverkernel.hpp
+++ b/server/src/hardware/protocol/z21/serverkernel.hpp
@@ -29,6 +29,7 @@
 #include <unordered_map>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/signals2/signal.hpp>
+#include <traintastic/enum/tristate.hpp>
 #include "messages.hpp"
 
 class DecoderList;

--- a/server/src/hardware/protocol/z21/utils.hpp
+++ b/server/src/hardware/protocol/z21/utils.hpp
@@ -23,6 +23,9 @@
 #ifndef TRAINTASTIC_SERVER_HARDWARE_PROTOCOL_Z21_UTILS_HPP
 #define TRAINTASTIC_SERVER_HARDWARE_PROTOCOL_Z21_UTILS_HPP
 
+#include <cstdint>
+#include <traintastic/enum/direction.hpp>
+
 namespace Z21::Utils {
 
 inline constexpr uint8_t directionFlag = 0x80;

--- a/shared/src/traintastic/enum/logmessage.hpp
+++ b/shared/src/traintastic/enum/logmessage.hpp
@@ -134,6 +134,7 @@ enum class LogMessage : uint32_t
   W2006_COMMAND_STATION_DOES_NOT_SUPPORT_LOCO_SLOT_X = LogMessageOffset::warning + 2006,
   W2007_COMMAND_STATION_DOES_NOT_SUPPORT_THE_FAST_CLOCK_SLOT = LogMessageOffset::warning + 2007,
   W2018_TIMEOUT_NO_ECHO_WITHIN_X_MS = LogMessageOffset::warning + 2018,
+  W2019_Z21_BROADCAST_FLAG_MISMATCH = LogMessageOffset::warning + 2019,
   W9999_X = LogMessageOffset::warning + 9999,
 
   // Error:

--- a/shared/translations/en-us.txt
+++ b/shared/translations/en-us.txt
@@ -436,6 +436,7 @@ message:W2005=Output address %1 is invalid
 message:W2006=Command station does not support loco slot %1
 message:W2007=Command station does not support the fast clock slot
 message:W2018=Timeout, no echo within %1ms
+message:W2019=Z21 broadcast flags do not match requested ones
 message:W9999=%1
 
 object:id=Id


### PR DESCRIPTION
Request BC flags as keep alive timer until we get a valid reply

Maybe we should allow a Z21 not supporting BC flags? Currently if Z21 replies "None", traintastic keeps asking again.
This can be because:
- the "set" part was skipped and we received only original BC flags -> ask again (current behaviour)
- The Z21 does not support BC flags so "None" is actually the correct status -> switch to normal keep alive message

I think we should consider also the second case
