### PR TITLE
Z21 handle loco info

### DIFF
--- a/server/src/hardware/protocol/xpressnet/messages.cpp
+++ b/server/src/hardware/protocol/xpressnet/messages.cpp
@@ -25,10 +25,9 @@
 
 namespace XpressNet {
 
-uint8_t calcChecksum(const Message& msg)
+uint8_t calcChecksum(const Message& msg, const int dataSize)
 {
   const uint8_t* p = reinterpret_cast<const uint8_t*>(&msg);
-  const int dataSize = msg.dataSize();
   uint8_t checksum = p[0];
   for(int i = 1; i <= dataSize; i++)
     checksum ^= p[i];
@@ -40,9 +39,9 @@ void updateChecksum(Message& msg)
   *(reinterpret_cast<uint8_t*>(&msg) + msg.dataSize() + 1) = calcChecksum(msg);
 }
 
-bool isChecksumValid(const Message& msg)
+bool isChecksumValid(const Message& msg, const int dataSize)
 {
-  return calcChecksum(msg) == *(reinterpret_cast<const uint8_t*>(&msg) + msg.dataSize() + 1);
+  return calcChecksum(msg, dataSize) == *(reinterpret_cast<const uint8_t*>(&msg) + dataSize + 1);
 }
 
 std::string toString(const Message& message, bool raw)

--- a/server/src/hardware/protocol/xpressnet/messages.hpp
+++ b/server/src/hardware/protocol/xpressnet/messages.hpp
@@ -40,9 +40,14 @@ constexpr uint8_t idFeedbackBroadcast = 0x40;
 
 struct Message;
 
-uint8_t calcChecksum(const Message& msg);
+inline uint8_t calcChecksum(const Message& msg);
+uint8_t calcChecksum(const Message& msg, const int dataSize);
+
 void updateChecksum(Message& msg);
-bool isChecksumValid(const Message& msg);
+
+inline bool isChecksumValid(const Message& msg);
+bool isChecksumValid(const Message& msg, const int dataSize);
+
 std::string toString(const Message& message, bool raw = false);
 
 struct Message
@@ -589,6 +594,16 @@ namespace RoSoftS88XpressNetLI
       checksum = calcChecksum(*this);
     }
   };
+}
+
+inline uint8_t calcChecksum(const Message& msg)
+{
+  return calcChecksum(msg, msg.dataSize());
+}
+
+inline bool isChecksumValid(const Message& msg)
+{
+  return isChecksumValid(msg, msg.dataSize());
 }
 
 }

--- a/server/src/hardware/protocol/z21/clientkernel.cpp
+++ b/server/src/hardware/protocol/z21/clientkernel.cpp
@@ -133,19 +133,26 @@ void ClientKernel::receive(const Message& message)
               speed = reply.speedStep(), speedMax=reply.speedSteps(),
               dir = reply.direction(), val, maxFunc]()
               {
-                if(auto decoder = m_decoderController->getDecoder(DCC::getProtocol(address), address))
+                try
                 {
-                  float throttle = Decoder::speedStepToThrottle(speed, speedMax);
-
-                  decoder->emergencyStop = isEStop;
-                  decoder->direction = dir;
-
-                  decoder->throttle = throttle;
-
-                  for(int i = 0; i <= maxFunc; i++)
+                  if(auto decoder = m_decoderController->getDecoder(DCC::getProtocol(address), address))
                   {
-                    decoder->setFunctionValue(i, val[i]);
+                    float throttle = Decoder::speedStepToThrottle(speed, speedMax);
+
+                    decoder->emergencyStop = isEStop;
+                    decoder->direction = dir;
+
+                    decoder->throttle = throttle;
+
+                    for(int i = 0; i <= maxFunc; i++)
+                    {
+                      decoder->setFunctionValue(i, val[i]);
+                    }
                   }
+                }
+                catch(...)
+                {
+
                 }
               });
           }

--- a/server/src/hardware/protocol/z21/clientkernel.cpp
+++ b/server/src/hardware/protocol/z21/clientkernel.cpp
@@ -148,10 +148,15 @@ void ClientKernel::receive(const Message& message)
               targetSpeedStep = float(targetSpeedStep) / float(cache->speedSteps) * 126.0;
             }
 
-            if(cache->lastReceivedSpeedStep <= currentSpeedStep)
-              cache->speedTrend = LocoCache::Trend::Ascending;
-            else
-              cache->speedTrend = LocoCache::Trend::Descending;
+            if(!cache->speedTrendExplicitlySet)
+            {
+              //Calculate new speed trend
+              if(cache->lastReceivedSpeedStep <= currentSpeedStep)
+                cache->speedTrend = LocoCache::Trend::Ascending;
+              else
+                cache->speedTrend = LocoCache::Trend::Descending;
+            }
+            cache->speedTrendExplicitlySet = false;
 
             if(reply.speedSteps() != cache->speedSteps || reply.speedStep() != cache->speedStep)
             {
@@ -592,6 +597,7 @@ void ClientKernel::decoderChanged(const Decoder& decoder, DecoderChangeFlags cha
           if(cache->lastReceivedSpeedStep < newTargetSpeedStep)
             cache->lastReceivedSpeedStep = 126; //Reset to maximum
         }
+        cache->speedTrendExplicitlySet = true;
 
         //Update last seen time to ignore feedback messages of our own changes
         //This potentially ignores also user commands coming from Z21 if issued

--- a/server/src/hardware/protocol/z21/clientkernel.cpp
+++ b/server/src/hardware/protocol/z21/clientkernel.cpp
@@ -22,7 +22,6 @@
 
 #include "clientkernel.hpp"
 #include "messages.hpp"
-#include "../xpressnet/messages.hpp"
 #include "../../decoder/decoder.hpp"
 #include "../../decoder/decoderchangeflags.hpp"
 #include "../../input/inputcontroller.hpp"
@@ -64,7 +63,7 @@ void ClientKernel::receive(const Message& message)
     {
       const auto& lanX = static_cast<const LanX&>(message);
 
-      if(!XpressNet::isChecksumValid(*reinterpret_cast<const XpressNet::Message*>(&lanX.xheader)))
+      if(!LanX::isChecksumValid(lanX))
         break;
 
       switch(lanX.xheader)
@@ -349,7 +348,7 @@ void ClientKernel::decoderChanged(const Decoder& decoder, DecoderChangeFlags cha
       cmd.setSpeedStep(speedStep);
     }
 
-    cmd.checksum = XpressNet::calcChecksum(*reinterpret_cast<const XpressNet::Message*>(&cmd.xheader));
+    cmd.updateChecksum();
     postSend(cmd);
   }
   else if(has(changes, DecoderChangeFlags::FunctionValue))

--- a/server/src/hardware/protocol/z21/clientkernel.cpp
+++ b/server/src/hardware/protocol/z21/clientkernel.cpp
@@ -116,13 +116,13 @@ void ClientKernel::receive(const Message& message)
 
         case LAN_X_LOCO_INFO:
         {
-          const int n = message.dataLen() - 7;
-          if(n >= 7 && n <= 14)
+          if(message.dataLen() >= LanXLocoInfo::minMessageSize && message.dataLen() <= LanXLocoInfo::maxMessageSize)
           {
             const auto& reply = static_cast<const LanXLocoInfo&>(message);
 
+            const int maxFunc = reply.supportsF29F31() ? 31 : 28;
             bool val[31 + 1] = {};
-            const int maxFunc = (n >= 8) ? 31 : 28;
+
             for(int i = 0; i <= maxFunc; i++)
             {
               val[i] = reply.getFunction(i);

--- a/server/src/hardware/protocol/z21/clientkernel.cpp
+++ b/server/src/hardware/protocol/z21/clientkernel.cpp
@@ -72,48 +72,45 @@ void ClientKernel::receive(const Message& message)
         case LAN_X_BC:
           if(message == LanXBCTrackPowerOff() || message == LanXBCTrackShortCircuit())
           {
-            if(m_trackPowerOn != TriState::False)
-            {
-              m_trackPowerOn = TriState::False;
-
-              if(m_onTrackPowerOnChanged)
-                EventLoop::call(
-                  [this]()
-                  {
+            EventLoop::call(
+              [this]()
+              {
+                if(m_trackPowerOn != TriState::False)
+                {
+                  m_trackPowerOn = TriState::False;
+                  if(m_onTrackPowerOnChanged)
                     m_onTrackPowerOnChanged(false);
-                  });
-            }
+                }
+              });
           }
           else if(message == LanXBCTrackPowerOn())
           {
-            if(m_trackPowerOn != TriState::True)
-            {
-              m_trackPowerOn = TriState::True;
-
-              if(m_onTrackPowerOnChanged)
-                EventLoop::call(
-                  [this]()
-                  {
+            EventLoop::call(
+              [this]()
+              {
+                if(m_trackPowerOn != TriState::True)
+                {
+                  m_trackPowerOn = TriState::True;
+                  if(m_onTrackPowerOnChanged)
                     m_onTrackPowerOnChanged(true);
-                  });
-            }
+                }
+              });
           }
           break;
 
         case LAN_X_BC_STOPPED:
           if(message == LanXBCStopped())
           {
-            if(m_emergencyStop != TriState::True)
-            {
-              m_emergencyStop = TriState::True;
-
-              if(m_onEmergencyStop)
-                EventLoop::call(
-                  [this]()
+            if(m_onEmergencyStop)
+              EventLoop::call(
+                [this]()
+                {
+                  if(m_emergencyStop != TriState::True)
                   {
+                    m_emergencyStop = TriState::True;
                     m_onEmergencyStop();
-                  });
-            }
+                  }
+                });
           }
           break;
       }
@@ -246,29 +243,23 @@ void ClientKernel::receive(const Message& message)
                                     && (reply.centralState & Z21_CENTRALSTATE_SHORTCIRCUIT) == 0;
 
         const TriState trackPowerOn = toTriState(isTrackPowerOn);
-        if(m_trackPowerOn != trackPowerOn)
-        {
-          m_trackPowerOn = trackPowerOn;
+        const TriState stopState = toTriState(isStop);
 
-          if(m_onTrackPowerOnChanged)
-            EventLoop::call(
-              [this, isTrackPowerOn]()
-              {
-                m_onTrackPowerOnChanged(isTrackPowerOn);
-              });
-        }
+        EventLoop::call([this, trackPowerOn, stopState]()
+          {
+            if(m_trackPowerOn != trackPowerOn)
+            {
+              m_trackPowerOn = trackPowerOn;
+              if(m_onTrackPowerOnChanged)
+                m_onTrackPowerOnChanged(trackPowerOn == TriState::True);
+            }
 
-        if(m_emergencyStop != TriState::True && isStop)
-        {
-          m_emergencyStop = TriState::True;
-
-          if(m_onEmergencyStop)
-            EventLoop::call(
-              [this]()
-              {
-                m_onEmergencyStop();
-              });
-        }
+            if(m_emergencyStop != stopState)
+            {
+              m_emergencyStop = stopState;
+              m_onEmergencyStop();
+            }
+          });
       }
       break;
     }
@@ -296,32 +287,44 @@ void ClientKernel::receive(const Message& message)
 
 void ClientKernel::trackPowerOn()
 {
-  m_ioContext.post(
-    [this]()
-    {
-      if(m_trackPowerOn != TriState::True || m_emergencyStop != TriState::False)
+  assert(isEventLoopThread());
+
+  if(m_trackPowerOn != TriState::True || m_emergencyStop != TriState::False)
+  {
+    m_ioContext.post(
+      [this]()
+      {
         send(LanXSetTrackPowerOn());
-    });
+      });
+  }
 }
 
 void ClientKernel::trackPowerOff()
 {
-  m_ioContext.post(
-    [this]()
-    {
-      if(m_trackPowerOn != TriState::False)
+  assert(isEventLoopThread());
+
+  if(m_trackPowerOn != TriState::False)
+  {
+    m_ioContext.post(
+      [this]()
+      {
         send(LanXSetTrackPowerOff());
-    });
+      });
+  }
 }
 
 void ClientKernel::emergencyStop()
 {
-  m_ioContext.post(
-    [this]()
-    {
-      if(m_emergencyStop != TriState::True)
+  assert(isEventLoopThread());
+
+  if(m_emergencyStop != TriState::True)
+  {
+    m_ioContext.post(
+      [this]()
+      {
         send(LanXSetStop());
-    });
+      });
+  }
 }
 
 void ClientKernel::decoderChanged(const Decoder& decoder, DecoderChangeFlags changes, uint32_t functionNumber)

--- a/server/src/hardware/protocol/z21/clientkernel.cpp
+++ b/server/src/hardware/protocol/z21/clientkernel.cpp
@@ -53,9 +53,9 @@ void ClientKernel::receive(const Message& message)
 {
   if(m_config.debugLogRXTX)
     EventLoop::call(
-      [this, msg=toString(message)]()
+      [logId_=logId, msg=toString(message)]()
       {
-        Log::log(logId, LogMessage::D2002_RX_X, msg);
+        Log::log(logId_, LogMessage::D2002_RX_X, msg);
       });
 
   switch(message.header())
@@ -519,9 +519,9 @@ void ClientKernel::send(const Message& message)
   {
     if(m_config.debugLogRXTX)
       EventLoop::call(
-        [this, msg=toString(message)]()
+        [logId_=logId, msg=toString(message)]()
         {
-          Log::log(logId, LogMessage::D2001_TX_X, msg);
+          Log::log(logId_, LogMessage::D2001_TX_X, msg);
         });
   }
   else

--- a/server/src/hardware/protocol/z21/clientkernel.hpp
+++ b/server/src/hardware/protocol/z21/clientkernel.hpp
@@ -91,10 +91,18 @@ class ClientKernel final : public Kernel
 
     struct LocoCache
     {
+      enum class Trend : bool
+      {
+          Ascending = 0,
+          Descending
+      };
+
       uint16_t dccAddress = 0;
+      bool isEStop = false;
       uint8_t speedStep = 0;
       uint8_t speedSteps = 0;
-      bool isEStop = false;
+      uint8_t lastReceivedSpeedStep = 0; //Always in 126 steps
+      Trend speedTrend = Trend::Ascending;
       Direction direction = Direction::Unknown;
       std::chrono::steady_clock::time_point lastSetTime;
     };

--- a/server/src/hardware/protocol/z21/clientkernel.hpp
+++ b/server/src/hardware/protocol/z21/clientkernel.hpp
@@ -103,6 +103,7 @@ class ClientKernel final : public Kernel
       uint8_t speedSteps = 0;
       uint8_t lastReceivedSpeedStep = 0; //Always in 126 steps
       Trend speedTrend = Trend::Ascending;
+      bool speedTrendExplicitlySet = false;
       Direction direction = Direction::Unknown;
       std::chrono::steady_clock::time_point lastSetTime;
     };

--- a/server/src/hardware/protocol/z21/clientkernel.hpp
+++ b/server/src/hardware/protocol/z21/clientkernel.hpp
@@ -62,6 +62,7 @@ class ClientKernel final : public Kernel
   private:
     const bool m_simulation;
     boost::asio::steady_timer m_keepAliveTimer;
+    boost::asio::steady_timer m_inactiveDecoderPurgeTimer;
     BroadcastFlags m_broadcastFlags;
     int m_broadcastFlagsRetryCount;
     static constexpr int maxBroadcastFlagsRetryCount = 10;
@@ -87,6 +88,18 @@ class ClientKernel final : public Kernel
     std::function<void()> m_onEmergencyStop;
 
     DecoderController* m_decoderController = nullptr;
+
+    struct LocoCache
+    {
+      uint16_t dccAddress = 0;
+      uint8_t speedStep = 0;
+      uint8_t speedSteps = 0;
+      bool isEStop = false;
+      Direction direction = Direction::Unknown;
+      std::chrono::steady_clock::time_point lastSetTime;
+    };
+
+    std::unordered_map<uint16_t, LocoCache> m_locoCache;
 
     InputController* m_inputController = nullptr;
     std::array<TriState, rbusAddressMax - rbusAddressMin + 1> m_rbusFeedbackStatus;
@@ -116,7 +129,11 @@ class ClientKernel final : public Kernel
     void startKeepAliveTimer();
     void keepAliveTimerExpired(const boost::system::error_code& ec);
 
-  public:
+    void startInactiveDecoderPurgeTimer();
+    void inactiveDecoderPurgeTimerExpired(const boost::system::error_code &ec);
+
+    LocoCache *getLocoCache(uint16_t dccAddr);
+public:
     /**
      * @brief Create kernel and IO handler
      * @param[in] config Z21 client configuration

--- a/server/src/hardware/protocol/z21/clientkernel.hpp
+++ b/server/src/hardware/protocol/z21/clientkernel.hpp
@@ -100,6 +100,7 @@ class ClientKernel final : public Kernel
     };
 
     std::unordered_map<uint16_t, LocoCache> m_locoCache;
+    bool isUpdatingDecoderFromKernel = false;
 
     InputController* m_inputController = nullptr;
     std::array<TriState, rbusAddressMax - rbusAddressMin + 1> m_rbusFeedbackStatus;

--- a/server/src/hardware/protocol/z21/config.hpp
+++ b/server/src/hardware/protocol/z21/config.hpp
@@ -35,6 +35,7 @@ struct Config
 struct ClientConfig : Config
 {
   static constexpr uint16_t keepAliveInterval = 15; //!< sec
+  static constexpr uint16_t purgeInactiveDecoderInternal = 5 * 60; //!< sec
 };
 
 struct ServerConfig : Config

--- a/server/src/hardware/protocol/z21/iohandler/simulationiohandler.cpp
+++ b/server/src/hardware/protocol/z21/iohandler/simulationiohandler.cpp
@@ -60,7 +60,7 @@ bool SimulationIOHandler::send(const Message& message)
               response.db1 |= Z21_CENTRALSTATE_EMERGENCYSTOP;
             if(!m_trackPowerOn)
               response.db1 |= Z21_CENTRALSTATE_TRACKVOLTAGEOFF;
-            response.calcChecksum();
+            response.updateChecksum();
             reply(response);
           }
           else if(message == LanXSetTrackPowerOn())

--- a/server/src/hardware/protocol/z21/messages.cpp
+++ b/server/src/hardware/protocol/z21/messages.cpp
@@ -306,6 +306,12 @@ bool LanX::isChecksumValid(const LanX &lanX)
 {
   const XpressNet::Message& msg = *reinterpret_cast<const XpressNet::Message*>(&lanX.xheader);
   int dataSize = msg.dataSize();
+  if(lanX.xheader == LAN_X_LOCO_INFO)
+  {
+    //Special case for variable length message
+    dataSize = lanX.dataLen() - 6;
+  }
+
   return XpressNet::isChecksumValid(msg, dataSize);
 }
 

--- a/server/src/hardware/protocol/z21/messages.cpp
+++ b/server/src/hardware/protocol/z21/messages.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "messages.hpp"
+#include "../xpressnet/messages.hpp"
 #include "../../decoder/decoder.hpp"
 #include "../../../core/objectproperty.tpp"
 #include "../../../utils/tohex.hpp"
@@ -291,7 +292,21 @@ LanXLocoInfo::LanXLocoInfo(const Decoder& decoder) :
     setSpeedStep(Decoder::throttleToSpeedStep(decoder.throttle, speedSteps()));
   for(const auto &function : *decoder.functions)
     setFunction(function->number, function->value);
-  calcChecksum();
+  updateChecksum();
+}
+
+void LanX::updateChecksum(uint8_t len)
+{
+  uint8_t val = XpressNet::calcChecksum(*reinterpret_cast<const XpressNet::Message*>(&xheader), len);
+  uint8_t* checksum = &xheader + len + 1;
+  *checksum = val;
+}
+
+bool LanX::isChecksumValid(const LanX &lanX)
+{
+  const XpressNet::Message& msg = *reinterpret_cast<const XpressNet::Message*>(&lanX.xheader);
+  int dataSize = msg.dataSize();
+  return XpressNet::isChecksumValid(msg, dataSize);
 }
 
 }

--- a/server/src/hardware/protocol/z21/messages.hpp
+++ b/server/src/hardware/protocol/z21/messages.hpp
@@ -546,6 +546,24 @@ struct LanXSetLocoDrive : LanX
     addressLow = longAddress ? address & 0xFF : address & 0x7F;
   }
 
+  inline void setSpeedSteps(uint8_t steps)
+  {
+    switch(steps)
+    {
+    case 14:
+      db0 = 0x10;
+      break;
+    case 28:
+      db0 = 0x12;
+      break;
+    case 126:
+    case 128:
+    default:
+      db0 = 0x13;
+      break;
+    }
+  }
+
   inline uint8_t speedSteps() const
   {
     switch(db0 & 0x0F)

--- a/server/src/hardware/protocol/z21/messages.hpp
+++ b/server/src/hardware/protocol/z21/messages.hpp
@@ -1109,14 +1109,14 @@ struct LanXLocoInfo : LanX
   static constexpr uint8_t flagF0 = 0x10;
   static constexpr uint8_t functionIndexMax = 28;
 
-  uint8_t addressHigh = 0;
-  uint8_t addressLow = 0;
+  uint8_t addressHigh = 0; //db0
+  uint8_t addressLow = 0;  //db1
   uint8_t db2 = 0;
-  uint8_t speedAndDirection = 0;
+  uint8_t speedAndDirection = 0; //db3
   uint8_t db4 = 0;
-  uint8_t f5f12 = 0;
-  uint8_t f13f20 = 0;
-  uint8_t f21f28 = 0;
+  uint8_t f5f12 = 0;    //db5
+  uint8_t f13f20 = 0;   //db6
+  uint8_t f21f28 = 0;   //db7
   uint8_t checksum = 0;
 
   LanXLocoInfo() :
@@ -1268,11 +1268,10 @@ struct LanXLocoInfo : LanX
     }
   }
 
-  void updateChecksum()
+  inline void updateChecksum()
   {
-    checksum = xheader;
-    for(uint8_t* db = &addressHigh; db < &checksum; db++)
-      checksum ^= *db;
+    //Data length - 7 Z21 header bytes + 1 byte for db0
+    LanX::updateChecksum(dataLen() - 6);
   }
 } ATTRIBUTE_PACKED;
 static_assert(sizeof(LanXLocoInfo) == 14);

--- a/server/src/hardware/protocol/z21/messages.hpp
+++ b/server/src/hardware/protocol/z21/messages.hpp
@@ -265,18 +265,15 @@ struct LanX : Message
   {
   }
 
-  void calcChecksum(uint8_t len)
+  void updateChecksum(uint8_t len);
+
+  inline void updateChecksum()
   {
-    uint8_t* checksum = &xheader + len + 1;
-    *checksum = xheader;
-    for(uint8_t* db = &xheader + 1; db < checksum; db++)
-      *checksum ^= *db;
+    updateChecksum(xheader & 0x0F);
   }
 
-  inline void calcChecksum()
-  {
-    calcChecksum(xheader & 0x0F);
-  }
+  static bool isChecksumValid(const LanX& lanX);
+
 } ATTRIBUTE_PACKED;
 static_assert(sizeof(LanX) == 5);
 
@@ -402,7 +399,7 @@ struct LanXGetTurnoutInfo : LanX
     , db0(address >> 8)
     , db1(address & 0xFF)
   {
-    calcChecksum();
+    updateChecksum();
   }
 
   uint16_t address() const
@@ -436,7 +433,7 @@ struct LanXSetTurnout : LanX
     if(linearAddress & 0x0001)
       db2 |= db2Port;
 
-    calcChecksum();
+    updateChecksum();
   }
 
   uint16_t address() const
@@ -490,7 +487,7 @@ struct LanXGetLocoInfo : LanX
     LanX(sizeof(LanXGetLocoInfo),  0xE3)
   {
     setAddress(address, longAddress);
-    calcChecksum();
+    updateChecksum();
   }
 
   inline uint16_t address() const
@@ -641,7 +638,7 @@ struct LanXSetLocoFunction : LanX
     setAddress(address, longAddress);
     setFunctionIndex(functionIndex);
     setSwitchType(value);
-    calcChecksum();
+    updateChecksum();
   }
 
   inline uint16_t address() const
@@ -926,7 +923,7 @@ struct LanXGetVersionReply : LanX
   {
     setXBusVersion(_xBusVersion);
     commandStationId = _commandStationId;
-    calcChecksum();
+    updateChecksum();
   }
 
   inline uint8_t xBusVersion() const
@@ -962,7 +959,7 @@ struct LanXGetFirmwareVersionReply : LanX
   {
     setVersionMajor(_major);
     setVersionMinor(_minor);
-    calcChecksum();
+    updateChecksum();
   }
 
   inline uint8_t versionMajor() const
@@ -1271,7 +1268,7 @@ struct LanXLocoInfo : LanX
     }
   }
 
-  void calcChecksum()
+  void updateChecksum()
   {
     checksum = xheader;
     for(uint8_t* db = &addressHigh; db < &checksum; db++)

--- a/server/src/hardware/protocol/z21/serverkernel.cpp
+++ b/server/src/hardware/protocol/z21/serverkernel.cpp
@@ -109,7 +109,7 @@ void ServerKernel::receiveFrom(const Message& message, IOHandler::ClientId clien
               response.db1 |= Z21_CENTRALSTATE_EMERGENCYSTOP;
             if(m_trackPowerOn != TriState::True)
               response.db1 |= Z21_CENTRALSTATE_TRACKVOLTAGEOFF;
-            response.calcChecksum();
+            response.updateChecksum();
             sendTo(response, clientId);
           }
           else if(message == LanXSetTrackPowerOn())

--- a/server/src/hardware/protocol/z21/utils.hpp
+++ b/server/src/hardware/protocol/z21/utils.hpp
@@ -61,7 +61,7 @@ constexpr bool isEmergencyStop(uint8_t db, uint8_t speedSteps)
 
 constexpr void setEmergencyStop(uint8_t& db)
 {
-  db = (db & directionFlag) | 0x01;
+  db = (db & directionFlag) | 0x01; // preserve direction flag
 }
 
 constexpr uint8_t getSpeedStep(uint8_t db, uint8_t speedSteps)
@@ -77,6 +77,8 @@ constexpr uint8_t getSpeedStep(uint8_t db, uint8_t speedSteps)
 
     case 28:
       db = ((db & 0x0F) << 1) | ((db & 0x10) >> 4); //! @todo check
+      if(db >= 3)
+          db -= 2;
       break;
 
     case 14:
@@ -86,7 +88,7 @@ constexpr uint8_t getSpeedStep(uint8_t db, uint8_t speedSteps)
     default:
       return 0;
   }
-  return db > 1 ? db - 1 : 0; // step 1 = EStop
+  return db >= 1 ? db - 1 : 0; // step 1 = EStop
 }
 
 constexpr void setSpeedStep(uint8_t& db, uint8_t speedSteps, uint8_t speedStep)
@@ -100,7 +102,8 @@ constexpr void setSpeedStep(uint8_t& db, uint8_t speedSteps, uint8_t speedStep)
         break;
 
       case 28:
-        db |= ((speedStep >> 1) & 0x0F) | ((speedStep << 4) & 0x01);
+        speedStep += 2;
+        db |= ((speedStep >> 1) & 0x0F) | ((speedStep & 0x01) << 4);
         break;
 
       case 14:


### PR DESCRIPTION
This PR handles receiving loco state from Z21 and update relevant Decoders.

- Needs #64 first
- Fix 28 steps format (not tested but coherent with protocol specifications and JMRI source code)
- Added support for receiving F29 - F31 (When Z21 firmware version is >= 1.42)
- Use helper functions for LanXSetLocoDrive instead of complex to read bit shifting
- Fix infinite loop explained in issue #57 (fixes #57)