### PR TITLE
Z21 pending request queue

### DIFF
--- a/server/src/hardware/protocol/z21/clientkernel.cpp
+++ b/server/src/hardware/protocol/z21/clientkernel.cpp
@@ -1047,9 +1047,10 @@ std::optional<ClientKernel::PendingRequest> ClientKernel::matchPendingReplyAndRe
       if(message.header() == LAN_X
           && static_cast<const LanX&>(message).xheader == LAN_X_LOCO_INFO)
       {
-        // TODO: Do extensive matching
         const LanXLocoInfo& locoInfo = static_cast<const LanXLocoInfo&>(message);
-        if(locoInfo.speedStep() != request->reply.speedStep)
+        if(locoInfo.speedAndDirection != request->reply.speedAndDirection)
+          continue;
+        if(locoInfo.speedSteps() != request->reply.speedSteps())
           continue;
       }
     }

--- a/server/src/hardware/protocol/z21/clientkernel.cpp
+++ b/server/src/hardware/protocol/z21/clientkernel.cpp
@@ -158,13 +158,16 @@ void ClientKernel::receive(const Message& message)
 
         case LAN_X_LOCO_INFO:
         {
+          bool isAnswerToOurRequest = false;
+
           if(matchedRequest)
           {
-            // Keep it only if it loco status was explicitly requested
             auto msgData = matchedRequest.value().messageBytes.data();
             const LanX& requestMsg = *reinterpret_cast<const LanX *>(msgData);
+
+            // If we explicitly requested loco info then we treat it as external change
             if(requestMsg.xheader != LAN_X_GET_LOCO_INFO)
-              break;
+              isAnswerToOurRequest = true;
           }
 
           if(message.dataLen() >= LanXLocoInfo::minMessageSize && message.dataLen() <= LanXLocoInfo::maxMessageSize)
@@ -193,69 +196,19 @@ void ClientKernel::receive(const Message& message)
                 currentSpeedStep = cache.lastReceivedSpeedStep; //Consider it a rounding error
             }
 
-            int targetSpeedStep = cache.speedStep;
-            if(cache.speedSteps != 126)
+            // For answers to our own requests we don't care about direction and speed step
+            if(cache.lastReceivedSpeedStep != currentSpeedStep)
             {
-              targetSpeedStep = float(targetSpeedStep) / float(cache.speedSteps) * 126.0;
-            }
-
-            if(!cache.speedTrendExplicitlySet)
-            {
-              //Calculate new speed trend
-              if(cache.lastReceivedSpeedStep <= currentSpeedStep)
-                cache.speedTrend = LocoCache::Trend::Ascending;
-              else
-                cache.speedTrend = LocoCache::Trend::Descending;
-            }
-            cache.speedTrendExplicitlySet = false;
-
-            if(reply.speedSteps() != cache.speedSteps || reply.speedStep() != cache.speedStep)
-            {
-              // Use a timeout of 1 second to prevent reacting to Z21 feedback messages
-              // of our own changes. This would be problematic because in the meatime our
-              // changes were sent to Z21 processed and received back here, decoder state
-              // might have changed (and sent again to Z21) so we should discard "old" state.
-              // This has the potential of ignoring genuine user changes for this decoder
-              // (made by a physical throttle or other hardware connected to Z21) but
-              // being the timeout short it should rarely happen.
-              // Theoretically the timeout should only be of Train::updateSpeed() timer timeout
-              // (100ms) because values will be refreshed and timeout restarted by Train itself
-              // but we need to accout also for network trasmission and Z21 processing time.
-
-              if((std::chrono::steady_clock::now() - cache.lastSetTime) > std::chrono::milliseconds(1000))
-              {
-                if(reply.speedSteps() != cache.speedSteps)
-                {
+                if(!isAnswerToOurRequest)
                   changes |= DecoderChangeFlags::SpeedSteps;
-                }
-                if(reply.speedStep() != cache.speedStep)
-                {
-                  changes |= DecoderChangeFlags::Throttle;
-                }
+                cache.lastReceivedSpeedStep = currentSpeedStep;
+            }
 
-                cache.speedSteps = reply.speedSteps();
-                cache.speedStep = reply.speedStep();
-              }
-              else
-              {
-                bool maybeOldFeedback = false;
-
-                if((cache.speedTrend == LocoCache::Trend::Ascending && currentSpeedStep <= targetSpeedStep)
-                    || (cache.speedTrend == LocoCache::Trend::Descending && currentSpeedStep >= targetSpeedStep))
-                {
-                  //When accelerating or decelerating ignore all speeds between original speed and target speed.
-                  //These messages are probably feedback of our own changes arrived with some delay.
-                  //If we get values outside this range or changing trend we pass them to let Train adjust.
-                  maybeOldFeedback = true;
-                }
-
-                if(!maybeOldFeedback)
-                {
-                  changes |= DecoderChangeFlags::Throttle | DecoderChangeFlags::SpeedSteps;
-                  cache.speedSteps = reply.speedSteps();
-                  cache.speedStep = reply.speedStep();
-                }
-              }
+            if(reply.speedSteps() != cache.speedSteps)
+            {
+              if(!isAnswerToOurRequest)
+                changes |= DecoderChangeFlags::SpeedSteps;
+              cache.speedSteps = reply.speedSteps();
             }
 
             //Emergency stop is urgent so bypass timeout
@@ -264,9 +217,11 @@ void ClientKernel::receive(const Message& message)
             //It can at worst cause a short flickering changing direction n times and then settle down
             if(reply.direction() != cache.direction)
             {
-              changes |= DecoderChangeFlags::Direction;
+              if(!isAnswerToOurRequest)
+                changes |= DecoderChangeFlags::Direction;
               cache.direction = reply.direction();
             }
+
             if(reply.isEmergencyStop() || reply.isEmergencyStop() != cache.isEStop)
             {
               //Force change when emergency stop is set to be sure it gets received
@@ -278,6 +233,15 @@ void ClientKernel::receive(const Message& message)
             //Do not update last seen time to avoid ignoring genuine user commands
             //Store last received speed step converted to 126 steps scale
             cache.lastReceivedSpeedStep = currentSpeedStep;
+
+            // Update last seen time to prevent decoder to be purged
+            cache.lastSetTime = std::chrono::steady_clock::now();
+
+            if(isAnswerToOurRequest && changes == DecoderChangeFlags(0))
+            {
+              // No need to notify Decoder
+              break;
+            }
 
             EventLoop::call(
               [this, address=reply.address(), isEStop=reply.isEmergencyStop(),
@@ -612,19 +576,6 @@ void ClientKernel::decoderChanged(const Decoder& decoder, DecoderChangeFlags cha
         }
       }
 
-      //Rescale everything to 126 steps
-      int oldTargetSpeedStep = cache.speedStep;
-      if(cache.speedSteps != 126)
-      {
-        oldTargetSpeedStep = float(oldTargetSpeedStep) / float(cache.speedSteps) * 126.0;
-      }
-
-      int newTargetSpeedStep = cmd.speedStep();
-      if(cmd.speedSteps() != 126)
-      {
-        newTargetSpeedStep = float(newTargetSpeedStep) / float(cmd.speedSteps()) * 126.0;
-      }
-
       if(changed)
       {
         cache.speedSteps = cmd.speedSteps();
@@ -632,23 +583,7 @@ void ClientKernel::decoderChanged(const Decoder& decoder, DecoderChangeFlags cha
         cache.direction = cmd.direction();
         cache.isEStop = cmd.isEmergencyStop();
 
-        if(newTargetSpeedStep >= oldTargetSpeedStep)
-        {
-          cache.speedTrend = LocoCache::Trend::Ascending;
-          if(cache.lastReceivedSpeedStep > newTargetSpeedStep)
-            cache.lastReceivedSpeedStep = 0; //Reset to minimum
-        }
-        else
-        {
-          cache.speedTrend = LocoCache::Trend::Descending;
-          if(cache.lastReceivedSpeedStep < newTargetSpeedStep)
-            cache.lastReceivedSpeedStep = 126; //Reset to maximum
-        }
-        cache.speedTrendExplicitlySet = true;
-
-        //Update last seen time to ignore feedback messages of our own changes
-        //This potentially ignores also user commands coming from Z21 if issued
-        //In less than 1 seconds from now
+        // Update last seen time to prevent decoder to be purged
         cache.lastSetTime = std::chrono::steady_clock::now();
       }
 

--- a/server/src/hardware/protocol/z21/clientkernel.cpp
+++ b/server/src/hardware/protocol/z21/clientkernel.cpp
@@ -38,6 +38,7 @@ ClientKernel::ClientKernel(std::string logId_, const ClientConfig& config, bool 
   , m_simulation{simulation}
   , m_keepAliveTimer(m_ioContext)
   , m_inactiveDecoderPurgeTimer(m_ioContext)
+  , m_schedulePendingRequestTimer(m_ioContext)
   , m_config{config}
 {
 }
@@ -59,6 +60,8 @@ void ClientKernel::receive(const Message& message)
       {
         Log::log(logId_, LogMessage::D2002_RX_X, msg);
       });
+
+  auto matchedRequest = matchPendingReplyAndRemove(message);
 
   switch(message.header())
   {
@@ -155,6 +158,15 @@ void ClientKernel::receive(const Message& message)
 
         case LAN_X_LOCO_INFO:
         {
+          if(matchedRequest)
+          {
+            // Keep it only if it loco status was explicitly requested
+            auto msgData = matchedRequest.value().messageBytes.data();
+            const LanX& requestMsg = *reinterpret_cast<const LanX *>(msgData);
+            if(requestMsg.xheader != LAN_X_GET_LOCO_INFO)
+              break;
+          }
+
           if(message.dataLen() >= LanXLocoInfo::minMessageSize && message.dataLen() <= LanXLocoInfo::maxMessageSize)
           {
             const auto& reply = static_cast<const LanXLocoInfo&>(message);
@@ -798,10 +810,12 @@ void ClientKernel::onStop()
 
   m_keepAliveTimer.cancel();
   m_inactiveDecoderPurgeTimer.cancel();
+  m_schedulePendingRequestTimer.cancel();
   m_locoCache.clear();
+  m_pendingRequests.clear();
 }
 
-void ClientKernel::send(const Message& message)
+void ClientKernel::send(const Message& message, bool wantReply, uint8_t customRetryCount)
 {
   if(m_ioHandler->send(message))
   {
@@ -811,6 +825,46 @@ void ClientKernel::send(const Message& message)
         {
           Log::log(logId_, LogMessage::D2001_TX_X, msg);
         });
+
+    if(wantReply)
+    {
+      PendingRequest request;
+      request.reply = getReplyType(message);
+
+      if(request.reply.header != MessageReplyType::noReply)
+      {
+        if(customRetryCount > 0)
+        {
+          request.retryCount = customRetryCount;
+        }
+        else
+        {
+          // Calculate from priority
+          switch (request.reply.priority())
+          {
+            case MessageReplyType::Priority::Low:
+              request.retryCount = 1;
+              break;
+
+            default:
+            case MessageReplyType::Priority::Normal:
+              request.retryCount = 2;
+              break;
+
+            case MessageReplyType::Priority::Urgent:
+              request.retryCount = 5;
+              break;
+          }
+        }
+
+        // Save copy of original message
+        request.messageBytes.resize(message.dataLen());
+        std::memcpy(request.messageBytes.data(), &message, message.dataLen());
+
+        // Enque pending request
+        addPendingRequest(request);
+      }
+    }
   }
   else
   {} // log message and go to error state
@@ -901,6 +955,173 @@ ClientKernel::LocoCache& ClientKernel::getLocoCache(uint16_t dccAddr)
   }
 
   return it->second;
+}
+
+void ClientKernel::addPendingRequest(const PendingRequest &request)
+{
+  //Enqueue this request to track reply from Z21
+  bool wasEmpty = m_pendingRequests.empty();
+  PendingRequest req = request;
+  req.sendTime = std::chrono::steady_clock::now();
+  m_pendingRequests.push_back(req);
+  if(wasEmpty)
+    startSchedulePendingRequestTimer();
+}
+
+std::optional<ClientKernel::PendingRequest> ClientKernel::matchPendingReplyAndRemove(const Message &message)
+{
+  const auto currentTime = std::chrono::steady_clock::now();
+
+  //TODO: depends on priority and network estimated speed
+  const auto timeout = std::chrono::seconds(3);
+
+  for(auto request = m_pendingRequests.begin(); request != m_pendingRequests.end(); request++)
+  {
+    //If it's last retry and we exceeded timeout, skip request
+    if(request->retryCount == 0 && (currentTime - request->sendTime) > timeout)
+      continue;
+
+    if(message.header() != request->reply.header)
+      continue;
+
+    if(message.header() == LAN_X)
+    {
+      const LanX& lanX = static_cast<const LanX&>(message);
+      if(lanX.xheader != request->reply.xHeader)
+        continue;
+
+      if(request->reply.hasFlag(MessageReplyType::Flags::CheckDb0))
+      {
+        // Cast to any LanX message with a db0 to check its value
+        const LanXGetStatus& hack = static_cast<const LanXGetStatus&>(lanX);
+        if(hack.db0 != request->reply.db0)
+          continue;
+      }
+    }
+
+    if(request->reply.hasFlag(MessageReplyType::Flags::CheckAddress))
+    {
+      uint16_t address = 0;
+      switch (message.header())
+      {
+        case LAN_GET_LOCO_MODE:
+        {
+          address = static_cast<const LanGetLocoMode&>(message).address();
+          break;
+        }
+
+        case LAN_GET_TURNOUTMODE:
+        {
+          // NOTE: not (yet) supported
+          break;
+        }
+
+        case LAN_X:
+        {
+          const LanX& lanX = static_cast<const LanX&>(message);
+          switch (lanX.xheader)
+          {
+            case LAN_X_TURNOUT_INFO:
+              address = static_cast<const LanXTurnoutInfo&>(lanX).address();
+              break;
+
+            case LAN_X_LOCO_INFO:
+              address = static_cast<const LanXLocoInfo&>(lanX).address();
+              break;
+
+            default:
+              break;
+          }
+        }
+
+        default:
+          break;
+      }
+
+      if(address != request->reply.address)
+        continue;
+    }
+
+    if(request->reply.hasFlag(MessageReplyType::Flags::CheckSpeedStep))
+    {
+      if(message.header() == LAN_X
+          && static_cast<const LanX&>(message).xheader == LAN_X_LOCO_INFO)
+      {
+        // TODO: Do extensive matching
+        const LanXLocoInfo& locoInfo = static_cast<const LanXLocoInfo&>(message);
+        if(locoInfo.speedStep() != request->reply.speedStep)
+          continue;
+      }
+    }
+
+    // We matched a previously sent request
+    // NOTE: In theory we could have matched a reply generated by other clients operations
+    // But for our purposes this should be fine
+
+    // Remove it from pending queue
+    PendingRequest copy = *request;
+    m_pendingRequests.erase(request);
+    return copy;
+  }
+
+  return {};
+}
+
+void ClientKernel::startSchedulePendingRequestTimer()
+{
+  //TODO: depends on priority and network estimated speed
+  const auto timeout = std::chrono::seconds(1);
+
+  m_schedulePendingRequestTimer.expires_after(timeout);
+  m_schedulePendingRequestTimer.async_wait(std::bind(&ClientKernel::schedulePendingRequestTimerExpired, this, std::placeholders::_1));
+}
+
+void ClientKernel::schedulePendingRequestTimerExpired(const boost::system::error_code &ec)
+{
+  if(ec)
+    return;
+
+  rescheduleTimedoutRequests();
+}
+
+void ClientKernel::rescheduleTimedoutRequests()
+{
+  const auto deadlineTime = std::chrono::steady_clock::now();
+
+  //TODO: depends on priority and network estimated speed
+  const auto timeout = std::chrono::seconds(3);
+
+  auto request = m_pendingRequests.begin();
+  while(request != m_pendingRequests.end())
+  {
+    if((deadlineTime - request->sendTime) > timeout)
+    {
+      if(request->retryCount <= 0)
+      {
+        // Give up with this request and remove it
+        request = m_pendingRequests.erase(request);
+        continue;
+      }
+
+      // Decrement retry count
+      request->retryCount--;
+
+      // Re-schedule request
+      auto msgData = request->messageBytes.data();
+      const Message& requestMsg = *reinterpret_cast<const Message *>(msgData);
+
+      // Send original request again but without adding it to pending queue
+      send(requestMsg, false);
+
+      // Restart timeout
+      request->sendTime = std::chrono::steady_clock::now();
+    }
+
+    request++;
+  }
+
+  if(!m_pendingRequests.empty())
+    startSchedulePendingRequestTimer();
 }
 
 }

--- a/server/src/hardware/protocol/z21/clientkernel.hpp
+++ b/server/src/hardware/protocol/z21/clientkernel.hpp
@@ -24,6 +24,7 @@
 #define TRAINTASTIC_SERVER_HARDWARE_PROTOCOL_Z21_CLIENTKERNEL_HPP
 
 #include <unordered_map>
+#include <optional>
 
 #include "kernel.hpp"
 #include <boost/asio/steady_timer.hpp>
@@ -67,6 +68,7 @@ class ClientKernel final : public Kernel
     const bool m_simulation;
     boost::asio::steady_timer m_keepAliveTimer;
     boost::asio::steady_timer m_inactiveDecoderPurgeTimer;
+    boost::asio::steady_timer m_schedulePendingRequestTimer;
     BroadcastFlags m_broadcastFlags;
     int m_broadcastFlagsRetryCount;
     static constexpr int maxBroadcastFlagsRetryCount = 10;
@@ -142,6 +144,17 @@ class ClientKernel final : public Kernel
     std::unordered_map<uint16_t, LocoCache> m_locoCache;
     bool m_isUpdatingDecoderFromKernel = false;
 
+    struct PendingRequest
+    {
+      std::vector<uint8_t> messageBytes;
+      Z21::MessageReplyType reply;
+      std::chrono::steady_clock::time_point sendTime;
+
+      //! Decrease at each re-send, remove request when reaches 0
+      uint8_t retryCount = 0;
+    };
+    std::vector<PendingRequest> m_pendingRequests;
+
     InputController* m_inputController = nullptr;
     std::array<TriState, rbusAddressMax - rbusAddressMin + 1> m_rbusFeedbackStatus;
     std::array<TriState, loconetAddressMax - loconetAddressMin + 1> m_loconetFeedbackStatus;
@@ -156,16 +169,16 @@ class ClientKernel final : public Kernel
     void onStop() final;
 
     template<class T>
-    void postSend(const T& message)
+    void postSend(const T& message, bool wantReply = true, uint8_t customRetryCount = 0)
     {
       m_ioContext.post(
-        [this, message]()
+        [this, message, wantReply, customRetryCount]()
         {
-          send(message);
+          send(message, wantReply, customRetryCount);
         });
     }
 
-    void send(const Message& message);
+    void send(const Message& message, bool wantReply = true, uint8_t customRetryCount = 0);
 
     void startKeepAliveTimer();
     void keepAliveTimerExpired(const boost::system::error_code& ec);
@@ -174,6 +187,12 @@ class ClientKernel final : public Kernel
     void inactiveDecoderPurgeTimerExpired(const boost::system::error_code &ec);
 
     LocoCache &getLocoCache(uint16_t dccAddr);
+
+    void addPendingRequest(const PendingRequest& request);
+    std::optional<PendingRequest> matchPendingReplyAndRemove(const Message& message);
+    void startSchedulePendingRequestTimer();
+    void schedulePendingRequestTimerExpired(const boost::system::error_code &ec);
+    void rescheduleTimedoutRequests();
 
 public:
     /**

--- a/server/src/hardware/protocol/z21/clientkernel.hpp
+++ b/server/src/hardware/protocol/z21/clientkernel.hpp
@@ -124,24 +124,31 @@ class ClientKernel final : public Kernel
 
     struct LocoCache
     {
-      enum class Trend : bool
-      {
-          Ascending = 0,
-          Descending
-      };
-
       uint16_t dccAddress = 0;
       bool isEStop = false;
       uint8_t speedStep = 0;
       uint8_t speedSteps = 0;
       uint8_t lastReceivedSpeedStep = 0; //Always in 126 steps
-      Trend speedTrend = Trend::Ascending;
-      bool speedTrendExplicitlySet = false;
       Direction direction = Direction::Unknown;
       std::chrono::steady_clock::time_point lastSetTime;
     };
 
+    /*!
+     * \brief m_locoCache stores last decoder states
+     *
+     * \note It must be accessed only from kernel thread or from
+     * Z21::ClientKernel::onStart().
+     */
     std::unordered_map<uint16_t, LocoCache> m_locoCache;
+
+    /*!
+     * \brief m_isUpdatingDecoderFromKernel prevents mirroring changes to Z21
+     *
+     * \note It must be accessed only from event loop thread or from
+     * Z21::ClientKernel::onStart().
+     *
+     * \sa EventLoop
+     */
     bool m_isUpdatingDecoderFromKernel = false;
 
     struct PendingRequest

--- a/server/src/hardware/protocol/z21/iohandler/simulationiohandler.cpp
+++ b/server/src/hardware/protocol/z21/iohandler/simulationiohandler.cpp
@@ -115,6 +115,7 @@ bool SimulationIOHandler::send(const Message& message)
               empty.setAddress(getLocoInfo.address(), getLocoInfo.isLongAddress());
               empty.setSpeedSteps(126);
               empty.setEmergencyStop();
+              empty.updateChecksum();
               reply(empty);
             }
           }
@@ -143,6 +144,9 @@ bool SimulationIOHandler::send(const Message& message)
               info.setEmergencyStop();
             else
               info.setSpeedStep(setLocoDrive.speedStep());
+
+            info.setBusy(true);
+            info.updateChecksum();
 
             reply(info);
           }
@@ -178,6 +182,9 @@ bool SimulationIOHandler::send(const Message& message)
               break;
             }
             info.setFunction(setLocoFunction.functionIndex(), val);
+
+            info.setBusy(true);
+            info.updateChecksum();
 
             reply(info);
           }

--- a/server/src/hardware/protocol/z21/iohandler/simulationiohandler.cpp
+++ b/server/src/hardware/protocol/z21/iohandler/simulationiohandler.cpp
@@ -194,7 +194,7 @@ bool SimulationIOHandler::send(const Message& message)
     case LAN_GET_BROADCASTFLAGS:
       if(message == LanGetBroadcastFlags())
       {
-        reply(LanSetBroadcastFlags(m_broadcastFlags));
+        reply(LanGetBroadcastFlagsReply(m_broadcastFlags));
       }
       break;
 

--- a/server/src/hardware/protocol/z21/iohandler/simulationiohandler.cpp
+++ b/server/src/hardware/protocol/z21/iohandler/simulationiohandler.cpp
@@ -49,6 +49,7 @@ bool SimulationIOHandler::send(const Message& message)
       switch(lanX.xheader)
       {
         case 0x21:
+        {
           if(message == LanXGetVersion())
           {
             reply(LanXGetVersionReply(xBusVersion, CommandStationId::Z21));
@@ -85,8 +86,9 @@ bool SimulationIOHandler::send(const Message& message)
             }
           }
           break;
-
+        }
         case LAN_X_SET_STOP:
+        {
           if(message == LanXSetStop())
           {
             const bool changed = !m_emergencyStop;
@@ -98,36 +100,97 @@ bool SimulationIOHandler::send(const Message& message)
             }
           }
           break;
-
+        }
         case LAN_X_GET_LOCO_INFO:
+        {
           if(const auto& getLocoInfo = static_cast<const LanXGetLocoInfo&>(message);
               getLocoInfo.db0 == 0xF0)
           {
-            // not (yet) supported
+            auto it = m_decoderCache.find(getLocoInfo.address());
+            if(it != m_decoderCache.cend())
+              reply(it->second);
+            else
+            {
+              LanXLocoInfo empty;
+              empty.setAddress(getLocoInfo.address(), getLocoInfo.isLongAddress());
+              empty.setSpeedSteps(126);
+              empty.setEmergencyStop();
+              reply(empty);
+            }
           }
           break;
-
+        }
         case LAN_X_SET_LOCO:
+        {
           if(const auto& setLocoDrive = static_cast<const LanXSetLocoDrive&>(message);
               setLocoDrive.db0 >= 0x10 && setLocoDrive.db0 <= 0x13)
           {
-            // not (yet) supported
+            std::unordered_map<uint16_t, LanXLocoInfo>::iterator it = m_decoderCache.find(setLocoDrive.address());
+            if(it == m_decoderCache.cend())
+            {
+              // Insert in cache
+              LanXLocoInfo empty;
+              empty.setAddress(setLocoDrive.address(), setLocoDrive.isLongAddress());
+              empty.setSpeedSteps(126);
+              empty.setEmergencyStop();
+              it = m_decoderCache.insert({setLocoDrive.address(), empty}).first;
+            }
+
+            LanXLocoInfo &info = it->second;
+            info.setSpeedSteps(setLocoDrive.speedSteps());
+            info.setDirection(setLocoDrive.direction());
+            if(setLocoDrive.isEmergencyStop())
+              info.setEmergencyStop();
+            else
+              info.setSpeedStep(setLocoDrive.speedStep());
+
+            reply(info);
           }
           else if(const auto& setLocoFunction = static_cast<const LanXSetLocoFunction&>(message);
                   setLocoFunction.db0 == 0xF8 &&
                   setLocoFunction.switchType() != LanXSetLocoFunction::SwitchType::Invalid)
           {
-            // not (yet) supported
+            std::unordered_map<uint16_t, LanXLocoInfo>::iterator it = m_decoderCache.find(setLocoDrive.address());
+            if(it == m_decoderCache.cend())
+            {
+              // Insert in cache
+                LanXLocoInfo empty;
+                empty.setAddress(setLocoFunction.address(), setLocoFunction.isLongAddress());
+                empty.setSpeedSteps(126);
+                empty.setEmergencyStop();
+                it = m_decoderCache.insert({setLocoFunction.address(), empty}).first;
+            }
+
+            LanXLocoInfo &info = it->second;
+            bool val = info.getFunction(setLocoFunction.functionIndex());
+            switch (setLocoFunction.switchType())
+            {
+            case LanXSetLocoFunction::SwitchType::Off:
+              val = false;
+              break;
+            case LanXSetLocoFunction::SwitchType::On:
+              val = true;
+              break;
+            case LanXSetLocoFunction::SwitchType::Toggle:
+              val = !val;
+              break;
+            default:
+              break;
+            }
+            info.setFunction(setLocoFunction.functionIndex(), val);
+
+            reply(info);
           }
           break;
-
+        }
         case LAN_X_GET_FIRMWARE_VERSION:
+        {
           if(message == LanXGetFirmwareVersion())
           {
             reply(LanXGetFirmwareVersionReply(firmwareVersionMajor, ServerConfig::firmwareVersionMinor));
           }
           break;
-
+        }
         case LAN_X_SET_TURNOUT:
         {
           if(message.dataLen() == sizeof(LanXSetTurnout))

--- a/server/src/hardware/protocol/z21/iohandler/simulationiohandler.hpp
+++ b/server/src/hardware/protocol/z21/iohandler/simulationiohandler.hpp
@@ -25,6 +25,7 @@
 
 #include "iohandler.hpp"
 #include <array>
+#include <unordered_map>
 #include "../messages.hpp"
 
 namespace Z21 {
@@ -41,6 +42,8 @@ class SimulationIOHandler final : public IOHandler
     bool m_emergencyStop = false;
     bool m_trackPowerOn = false;
     BroadcastFlags m_broadcastFlags = BroadcastFlags::None;
+
+    std::unordered_map<uint16_t, LanXLocoInfo> m_decoderCache;
 
     void reply(const Message& message);
     void replyLanSystemStateDataChanged();

--- a/server/src/hardware/protocol/z21/messages.cpp
+++ b/server/src/hardware/protocol/z21/messages.cpp
@@ -375,6 +375,7 @@ MessageReplyType getReplyType(const Message &message)
       reply.setPriority(MessageReplyType::Priority::Low);
       return reply;
     }
+
     case LAN_GET_BROADCASTFLAGS:
     case LAN_LOCONET_DETECTOR:
     case LAN_CAN_DETECTOR:

--- a/server/src/hardware/protocol/z21/messages.cpp
+++ b/server/src/hardware/protocol/z21/messages.cpp
@@ -496,7 +496,8 @@ MessageReplyType getReplyType(const Message &message)
                 setLocoDrive.db0 >= 0x10 && setLocoDrive.db0 <= 0x13)
             {
               reply.address = setLocoDrive.address();
-              reply.speedStep = setLocoDrive.speedStep();
+              reply.speedAndDirection = setLocoDrive.speedAndDirection;
+              reply.setSpeedSteps(setLocoDrive.speedSteps());
               reply.setFlag(MessageReplyType::Flags::CheckSpeedStep);
             }
             else if(const auto& setLocoFunction = static_cast<const LanXSetLocoFunction&>(message);

--- a/server/src/hardware/protocol/z21/messages.cpp
+++ b/server/src/hardware/protocol/z21/messages.cpp
@@ -361,4 +361,189 @@ bool LanX::isChecksumValid(const LanX &lanX)
   return XpressNet::isChecksumValid(msg, dataSize);
 }
 
+MessageReplyType getReplyType(const Message &message)
+{
+  switch (message.header())
+  {
+    //Messages whose replies have same header
+    case LAN_GET_SERIAL_NUMBER:
+    case LAN_GET_CODE:
+    case LAN_GET_HWINFO:
+    {
+      MessageReplyType reply;
+      reply.header = message.header();
+      reply.setPriority(MessageReplyType::Priority::Low);
+      return reply;
+    }
+    case LAN_GET_BROADCASTFLAGS:
+    case LAN_LOCONET_DETECTOR:
+    case LAN_CAN_DETECTOR:
+      return {message.header()};
+
+    case LAN_GET_LOCO_MODE:
+    case LAN_GET_TURNOUTMODE:
+    {
+      MessageReplyType reply;
+      reply.header = message.header();
+      reply.setFlag(MessageReplyType::Flags::CheckAddress);
+
+      if(message.header() == LAN_GET_LOCO_MODE)
+        reply.address = static_cast<const LanGetLocoMode&>(message).address();
+
+      // NOTE: not (yet) supported
+      //else
+      //  reply.address = static_cast<const LanGetTurnoutMode&>(message).address();
+
+      return reply;
+    }
+
+    // NOTE: This message has no reply for Z21 firmware < 1.22
+    // NOTE: not (yet) supported
+    case LAN_LOCONET_DISPATCH_ADDR:
+      return {LAN_LOCONET_DISPATCH_ADDR};
+
+    case LAN_X:
+    {
+      const LanX& lanX = static_cast<const LanX&>(message);
+      switch (lanX.xheader)
+      {
+        case 0x21:
+        {
+          MessageReplyType reply;
+          reply.header = LAN_X;
+          reply.setPriority(MessageReplyType::Priority::Low);
+          reply.setFlag(MessageReplyType::Flags::CheckDb0);
+
+          // Cast to any LanX message with a db0 to check its value
+          const LanXGetStatus& hack = static_cast<const LanXGetStatus&>(lanX);
+          switch (hack.db0)
+          {
+            case 0x21: // LAN_X_GET_VERSION
+            {
+              reply.xHeader = LAN_X_GET_VERSION_REPLY;
+              break;
+            }
+
+            case 0x24: // LAN_X_GET_STATUS
+            {
+              reply.xHeader = LAN_X_STATUS_CHANGED;
+              break;
+            }
+
+            case LAN_X_SET_TRACK_POWER_OFF:
+            {
+              reply.xHeader = LAN_X_BC;
+              reply.db0 = LAN_X_BC_TRACK_POWER_OFF;
+              reply.setPriority(MessageReplyType::Priority::Urgent);
+              break;
+            }
+
+            case LAN_X_SET_TRACK_POWER_ON:
+            {
+              //LAN_X_SET_TRACK_POWER_ON
+              reply.xHeader = LAN_X_BC;
+              reply.db0 = LAN_X_BC_TRACK_POWER_ON;
+              reply.setPriority(MessageReplyType::Priority::Urgent);
+              break;
+            }
+
+            default:
+              return {MessageReplyType::noReply};
+          }
+          return reply;
+        }
+
+        case LAN_X_TURNOUT_INFO:
+        case LAN_X_SET_TURNOUT:
+        {
+          MessageReplyType reply;
+          reply.header = LAN_X;
+          reply.xHeader = LAN_X_TURNOUT_INFO;
+          reply.setFlag(MessageReplyType::Flags::CheckAddress);
+
+          if(lanX.xheader == LAN_X_TURNOUT_INFO)
+            reply.address = static_cast<const LanXGetTurnoutInfo&>(lanX).address();
+          else
+            reply.address = static_cast<const LanXSetTurnout&>(lanX).address();
+
+          return reply;
+        }
+
+        case LAN_X_SET_STOP:
+        {
+          MessageReplyType reply;
+          reply.header = LAN_X;
+          reply.xHeader = LAN_X_BC_STOPPED;
+          reply.setPriority(MessageReplyType::Priority::Urgent);
+          return reply;
+        }
+
+        case LAN_X_GET_LOCO_INFO:
+        case LAN_X_SET_LOCO:
+        {
+          MessageReplyType reply;
+          reply.header = LAN_X;
+          reply.xHeader = LAN_X_LOCO_INFO;
+          reply.setFlag(MessageReplyType::Flags::CheckAddress);
+
+          if(lanX.xheader == LAN_X_GET_LOCO_INFO)
+          {
+            reply.address = static_cast<const LanXGetLocoInfo&>(lanX).address();
+          }
+          else
+          {
+            if(const auto& setLocoDrive = static_cast<const LanXSetLocoDrive&>(message);
+                setLocoDrive.db0 >= 0x10 && setLocoDrive.db0 <= 0x13)
+            {
+              reply.address = setLocoDrive.address();
+              reply.speedStep = setLocoDrive.speedStep();
+              reply.setFlag(MessageReplyType::Flags::CheckSpeedStep);
+            }
+            else if(const auto& setLocoFunction = static_cast<const LanXSetLocoFunction&>(message);
+                     setLocoFunction.db0 == 0xF8)
+            {
+              reply.address = setLocoFunction.address();
+            }
+            else
+            {
+              //Other loco function messages do not have standard reply
+              return {MessageReplyType::noReply};
+            }
+          }
+
+          return reply;
+        }
+
+        case LAN_X_GET_FIRMWARE_VERSION:
+        {
+          MessageReplyType reply;
+          reply.header = LAN_X;
+          reply.xHeader = LAN_X_GET_FIRMWARE_VERSION_REPLY;
+          reply.setPriority(MessageReplyType::Priority::Low);
+          return reply;
+        }
+
+        default:
+          break;
+      }
+      break;
+    }
+
+    case LAN_RMBUS_GETDATA:
+      return {LAN_RMBUS_DATACHANGED};
+
+    case LAN_SYSTEMSTATE_GETDATA:
+      return {LAN_SYSTEMSTATE_DATACHANGED};
+
+    case LAN_RAILCOM_GETDATA:
+      return {LAN_RAILCOM_DATACHANGED};
+
+    default:
+      break;
+  }
+
+  //Message has no reply or it's no supported by Traintastic
+  return {MessageReplyType::noReply};
+}
+
 }

--- a/server/src/hardware/protocol/z21/messages.hpp
+++ b/server/src/hardware/protocol/z21/messages.hpp
@@ -1698,6 +1698,69 @@ constexpr std::string_view toString(LanXSetLocoFunction::SwitchType value)
   return {};
 }
 
+struct MessageReplyType
+{
+  enum class Priority : uint8_t
+  {
+    Low = 0,
+    Normal = 1,
+    Urgent = 2
+  };
+
+  enum class Flags : uint8_t
+  {
+    CheckDb0       = 1 << 0,
+    CheckSpeedStep = 1 << 1,
+    CheckAddress   = 1 << 2
+  };
+
+  inline Priority priority() const
+  {
+    return Priority(m_flags & 0xF);
+  }
+
+  inline void setPriority(Priority value)
+  {
+    m_flags = uint8_t(getFlags()) << 4 | (uint8_t(value) & 0xF);
+  }
+
+  inline Flags getFlags() const
+  {
+    return Flags((m_flags >> 4) & 0xF);
+  }
+
+  inline bool hasFlag(Flags flag) const
+  {
+    return uint8_t(getFlags()) & uint8_t(flag);
+  }
+
+  inline void setFlag(Flags flag, bool on = true)
+  {
+    uint8_t flags = uint8_t(getFlags());
+    if(on)
+      flags |= uint8_t(flag);
+    else
+      flags &= ~uint8_t(flag);
+    setFlags(Flags(flags));
+  }
+
+  inline void setFlags(Flags flags)
+  {
+    m_flags = uint8_t(flags) << 4 | (uint8_t(priority()) & 0xF);
+  }
+
+  static constexpr Header noReply = Header(0);
+
+  Header header = noReply;
+  uint8_t xHeader = 0;
+  uint8_t db0 = 0;
+  uint16_t address = 0;
+  uint8_t m_flags = uint8_t(Priority::Normal);
+  uint8_t speedStep = 0;
+};
+
+MessageReplyType getReplyType(const Message &message);
+
 }
 
 inline bool operator ==(const Z21::Message& lhs, const Z21::Message& rhs)

--- a/server/src/hardware/protocol/z21/messages.hpp
+++ b/server/src/hardware/protocol/z21/messages.hpp
@@ -1749,6 +1749,30 @@ struct MessageReplyType
     m_flags = uint8_t(flags) << 4 | (uint8_t(priority()) & 0xF);
   }
 
+  inline uint8_t speedSteps() const
+  {
+    switch(speedStepsEncoded & LanXLocoInfo::db2_speed_steps_mask)
+    {
+      case LanXLocoInfo::db2_speed_steps_14:  return 14;
+      case LanXLocoInfo::db2_speed_steps_28:  return 28;
+      case LanXLocoInfo::db2_speed_steps_128: return 126;
+    }
+    return 0;
+  }
+
+  inline void setSpeedSteps(uint8_t value)
+  {
+    speedStepsEncoded &= ~LanXLocoInfo::db2_speed_steps_mask;
+    switch(value)
+    {
+      case 14:  speedStepsEncoded |= LanXLocoInfo::db2_speed_steps_14;  break;
+      case 28:  speedStepsEncoded |= LanXLocoInfo::db2_speed_steps_28;  break;
+      case 126:
+      case 128:
+      default:  speedStepsEncoded |= LanXLocoInfo::db2_speed_steps_128; break;
+    }
+  }
+
   static constexpr Header noReply = Header(0);
 
   Header header = noReply;
@@ -1756,7 +1780,10 @@ struct MessageReplyType
   uint8_t db0 = 0;
   uint16_t address = 0;
   uint8_t m_flags = uint8_t(Priority::Normal);
-  uint8_t speedStep = 0;
+
+  // Encoded as LAN_X_
+  uint8_t speedAndDirection = 0;
+  uint8_t speedStepsEncoded = 0;
 };
 
 MessageReplyType getReplyType(const Message &message);

--- a/server/src/hardware/protocol/z21/serverkernel.cpp
+++ b/server/src/hardware/protocol/z21/serverkernel.cpp
@@ -249,7 +249,7 @@ void ServerKernel::receiveFrom(const Message& message, IOHandler::ClientId clien
 
     case LAN_GET_BROADCASTFLAGS:
       if(message == LanGetBroadcastFlags())
-        sendTo(LanSetBroadcastFlags(m_clients[clientId].broadcastFlags), clientId);
+        sendTo(LanGetBroadcastFlagsReply(m_clients[clientId].broadcastFlags), clientId);
       break;
 
     case LAN_SET_BROADCASTFLAGS:


### PR DESCRIPTION
Pending request queue allows to retry sending messages after a timeout if expected reply is not received.
This also allows to detect a message is a reply to our own changes and react to it differently

See #60 for earlier discussion.

NOTE: needs #82 applied first

Both this and #82 `LocoCache` try to resolve the "async loop" issue (See #57).
This 2 solutions are orthogonal and can live together. 