### PR TITLE
New Z21 fixes

### DIFF
--- a/server/src/hardware/protocol/xpressnet/messages.cpp
+++ b/server/src/hardware/protocol/xpressnet/messages.cpp
@@ -25,10 +25,9 @@
 
 namespace XpressNet {
 
-uint8_t calcChecksum(const Message& msg)
+uint8_t calcChecksum(const Message& msg, const int dataSize)
 {
   const uint8_t* p = reinterpret_cast<const uint8_t*>(&msg);
-  const int dataSize = msg.dataSize();
   uint8_t checksum = p[0];
   for(int i = 1; i <= dataSize; i++)
     checksum ^= p[i];
@@ -40,9 +39,9 @@ void updateChecksum(Message& msg)
   *(reinterpret_cast<uint8_t*>(&msg) + msg.dataSize() + 1) = calcChecksum(msg);
 }
 
-bool isChecksumValid(const Message& msg)
+bool isChecksumValid(const Message& msg, const int dataSize)
 {
-  return calcChecksum(msg) == *(reinterpret_cast<const uint8_t*>(&msg) + msg.dataSize() + 1);
+  return calcChecksum(msg, dataSize) == *(reinterpret_cast<const uint8_t*>(&msg) + dataSize + 1);
 }
 
 std::string toString(const Message& message, bool raw)

--- a/server/src/hardware/protocol/xpressnet/messages.hpp
+++ b/server/src/hardware/protocol/xpressnet/messages.hpp
@@ -40,9 +40,14 @@ constexpr uint8_t idFeedbackBroadcast = 0x40;
 
 struct Message;
 
-uint8_t calcChecksum(const Message& msg);
+inline uint8_t calcChecksum(const Message& msg);
+uint8_t calcChecksum(const Message& msg, const int dataSize);
+
 void updateChecksum(Message& msg);
-bool isChecksumValid(const Message& msg);
+
+inline bool isChecksumValid(const Message& msg);
+bool isChecksumValid(const Message& msg, const int dataSize);
+
 std::string toString(const Message& message, bool raw = false);
 
 struct Message
@@ -589,6 +594,16 @@ namespace RoSoftS88XpressNetLI
       checksum = calcChecksum(*this);
     }
   };
+}
+
+inline uint8_t calcChecksum(const Message& msg)
+{
+  return calcChecksum(msg, msg.dataSize());
+}
+
+inline bool isChecksumValid(const Message& msg)
+{
+  return isChecksumValid(msg, msg.dataSize());
 }
 
 }

--- a/server/src/hardware/protocol/z21/clientkernel.cpp
+++ b/server/src/hardware/protocol/z21/clientkernel.cpp
@@ -22,7 +22,6 @@
 
 #include "clientkernel.hpp"
 #include "messages.hpp"
-#include "../xpressnet/messages.hpp"
 #include "../../decoder/decoder.hpp"
 #include "../../decoder/decoderchangeflags.hpp"
 #include "../../input/inputcontroller.hpp"
@@ -64,7 +63,7 @@ void ClientKernel::receive(const Message& message)
     {
       const auto& lanX = static_cast<const LanX&>(message);
 
-      if(!XpressNet::isChecksumValid(*reinterpret_cast<const XpressNet::Message*>(&lanX.xheader)))
+      if(!LanX::isChecksumValid(lanX))
         break;
 
       switch(lanX.xheader)
@@ -349,7 +348,7 @@ void ClientKernel::decoderChanged(const Decoder& decoder, DecoderChangeFlags cha
       cmd.setSpeedStep(speedStep);
     }
 
-    cmd.checksum = XpressNet::calcChecksum(*reinterpret_cast<const XpressNet::Message*>(&cmd.xheader));
+    cmd.updateChecksum();
     postSend(cmd);
   }
   else if(has(changes, DecoderChangeFlags::FunctionValue))

--- a/server/src/hardware/protocol/z21/clientkernel.cpp
+++ b/server/src/hardware/protocol/z21/clientkernel.cpp
@@ -72,48 +72,45 @@ void ClientKernel::receive(const Message& message)
         case LAN_X_BC:
           if(message == LanXBCTrackPowerOff() || message == LanXBCTrackShortCircuit())
           {
-            if(m_trackPowerOn != TriState::False)
-            {
-              m_trackPowerOn = TriState::False;
-
-              if(m_onTrackPowerOnChanged)
-                EventLoop::call(
-                  [this]()
-                  {
+            EventLoop::call(
+              [this]()
+              {
+                if(m_trackPowerOn != TriState::False)
+                {
+                  m_trackPowerOn = TriState::False;
+                  if(m_onTrackPowerOnChanged)
                     m_onTrackPowerOnChanged(false);
-                  });
-            }
+                }
+              });
           }
           else if(message == LanXBCTrackPowerOn())
           {
-            if(m_trackPowerOn != TriState::True)
-            {
-              m_trackPowerOn = TriState::True;
-
-              if(m_onTrackPowerOnChanged)
-                EventLoop::call(
-                  [this]()
-                  {
+            EventLoop::call(
+              [this]()
+              {
+                if(m_trackPowerOn != TriState::True)
+                {
+                  m_trackPowerOn = TriState::True;
+                  if(m_onTrackPowerOnChanged)
                     m_onTrackPowerOnChanged(true);
-                  });
-            }
+                }
+              });
           }
           break;
 
         case LAN_X_BC_STOPPED:
           if(message == LanXBCStopped())
           {
-            if(m_emergencyStop != TriState::True)
-            {
-              m_emergencyStop = TriState::True;
-
-              if(m_onEmergencyStop)
-                EventLoop::call(
-                  [this]()
-                  {
+            EventLoop::call(
+              [this]()
+              {
+                if(m_emergencyStop != TriState::True)
+                {
+                  m_emergencyStop = TriState::True;
+                  if(m_onEmergencyStop)
                     m_onEmergencyStop();
-                  });
-            }
+                }
+              });
           }
           break;
       }
@@ -246,29 +243,23 @@ void ClientKernel::receive(const Message& message)
                                     && (reply.centralState & Z21_CENTRALSTATE_SHORTCIRCUIT) == 0;
 
         const TriState trackPowerOn = toTriState(isTrackPowerOn);
-        if(m_trackPowerOn != trackPowerOn)
-        {
-          m_trackPowerOn = trackPowerOn;
+        const TriState stopState = toTriState(isStop);
 
-          if(m_onTrackPowerOnChanged)
-            EventLoop::call(
-              [this, isTrackPowerOn]()
-              {
-                m_onTrackPowerOnChanged(isTrackPowerOn);
-              });
-        }
+        EventLoop::call([this, trackPowerOn, stopState]()
+          {
+            if(m_trackPowerOn != trackPowerOn)
+            {
+              m_trackPowerOn = trackPowerOn;
+              if(m_onTrackPowerOnChanged)
+                m_onTrackPowerOnChanged(trackPowerOn == TriState::True);
+            }
 
-        if(m_emergencyStop != TriState::True && isStop)
-        {
-          m_emergencyStop = TriState::True;
-
-          if(m_onEmergencyStop)
-            EventLoop::call(
-              [this]()
-              {
-                m_onEmergencyStop();
-              });
-        }
+            if(m_emergencyStop != stopState)
+            {
+              m_emergencyStop = stopState;
+              m_onEmergencyStop();
+            }
+          });
       }
       break;
     }
@@ -296,32 +287,44 @@ void ClientKernel::receive(const Message& message)
 
 void ClientKernel::trackPowerOn()
 {
-  m_ioContext.post(
-    [this]()
-    {
-      if(m_trackPowerOn != TriState::True || m_emergencyStop != TriState::False)
+  assert(isEventLoopThread());
+
+  if(m_trackPowerOn != TriState::True || m_emergencyStop != TriState::False)
+  {
+    m_ioContext.post(
+      [this]()
+      {
         send(LanXSetTrackPowerOn());
-    });
+      });
+  }
 }
 
 void ClientKernel::trackPowerOff()
 {
-  m_ioContext.post(
-    [this]()
-    {
-      if(m_trackPowerOn != TriState::False)
+  assert(isEventLoopThread());
+
+  if(m_trackPowerOn != TriState::False)
+  {
+    m_ioContext.post(
+      [this]()
+      {
         send(LanXSetTrackPowerOff());
-    });
+      });
+  }
 }
 
 void ClientKernel::emergencyStop()
 {
-  m_ioContext.post(
-    [this]()
-    {
-      if(m_emergencyStop != TriState::True)
+  assert(isEventLoopThread());
+
+  if(m_emergencyStop != TriState::True)
+  {
+    m_ioContext.post(
+      [this]()
+      {
         send(LanXSetStop());
-    });
+      });
+  }
 }
 
 void ClientKernel::decoderChanged(const Decoder& decoder, DecoderChangeFlags changes, uint32_t functionNumber)

--- a/server/src/hardware/protocol/z21/clientkernel.cpp
+++ b/server/src/hardware/protocol/z21/clientkernel.cpp
@@ -53,9 +53,9 @@ void ClientKernel::receive(const Message& message)
 {
   if(m_config.debugLogRXTX)
     EventLoop::call(
-      [this, msg=toString(message)]()
+      [logId_=logId, msg=toString(message)]()
       {
-        Log::log(logId, LogMessage::D2002_RX_X, msg);
+        Log::log(logId_, LogMessage::D2002_RX_X, msg);
       });
 
   switch(message.header())
@@ -519,9 +519,9 @@ void ClientKernel::send(const Message& message)
   {
     if(m_config.debugLogRXTX)
       EventLoop::call(
-        [this, msg=toString(message)]()
+        [logId_=logId, msg=toString(message)]()
         {
-          Log::log(logId, LogMessage::D2001_TX_X, msg);
+          Log::log(logId_, LogMessage::D2001_TX_X, msg);
         });
   }
   else

--- a/server/src/hardware/protocol/z21/clientkernel.hpp
+++ b/server/src/hardware/protocol/z21/clientkernel.hpp
@@ -81,7 +81,24 @@ class ClientKernel final : public Kernel
     uint8_t m_firmwareVersionMinor;
     std::function<void(HardwareType, uint8_t, uint8_t)> m_onHardwareInfoChanged;
 
+    /*!
+     * \brief m_trackPowerOn caches command station track power state.
+     *
+     * NOTE: it must be accessed only from event loop thread or from
+     * Z21::ClientKernel::onStart().
+     *
+     * \sa EventLoop
+     */
     TriState m_trackPowerOn;
+
+    /*!
+     * \brief m_emergencyStop caches command station emergency stop state.
+     *
+     * NOTE: it must be accessed only from event loop thread or from
+     * Z21::ClientKernel::onStart().
+     *
+     * \sa EventLoop
+     */
     TriState m_emergencyStop;
     std::function<void(bool)> m_onTrackPowerOnChanged;
     std::function<void()> m_onEmergencyStop;

--- a/server/src/hardware/protocol/z21/iohandler/simulationiohandler.cpp
+++ b/server/src/hardware/protocol/z21/iohandler/simulationiohandler.cpp
@@ -60,7 +60,7 @@ bool SimulationIOHandler::send(const Message& message)
               response.db1 |= Z21_CENTRALSTATE_EMERGENCYSTOP;
             if(!m_trackPowerOn)
               response.db1 |= Z21_CENTRALSTATE_TRACKVOLTAGEOFF;
-            response.calcChecksum();
+            response.updateChecksum();
             reply(response);
           }
           else if(message == LanXSetTrackPowerOn())

--- a/server/src/hardware/protocol/z21/iohandler/simulationiohandler.cpp
+++ b/server/src/hardware/protocol/z21/iohandler/simulationiohandler.cpp
@@ -99,7 +99,7 @@ bool SimulationIOHandler::send(const Message& message)
           }
           break;
 
-        case 0xE3:
+        case LAN_X_GET_LOCO_INFO:
           if(const auto& getLocoInfo = static_cast<const LanXGetLocoInfo&>(message);
               getLocoInfo.db0 == 0xF0)
           {
@@ -107,7 +107,7 @@ bool SimulationIOHandler::send(const Message& message)
           }
           break;
 
-        case 0xE4:
+        case LAN_X_SET_LOCO:
           if(const auto& setLocoDrive = static_cast<const LanXSetLocoDrive&>(message);
               setLocoDrive.db0 >= 0x10 && setLocoDrive.db0 <= 0x13)
           {
@@ -121,7 +121,7 @@ bool SimulationIOHandler::send(const Message& message)
           }
           break;
 
-        case 0xF1:
+        case LAN_X_GET_FIRMWARE_VERSION:
           if(message == LanXGetFirmwareVersion())
           {
             reply(LanXGetFirmwareVersionReply(firmwareVersionMajor, ServerConfig::firmwareVersionMinor));

--- a/server/src/hardware/protocol/z21/messages.cpp
+++ b/server/src/hardware/protocol/z21/messages.cpp
@@ -306,6 +306,12 @@ bool LanX::isChecksumValid(const LanX &lanX)
 {
   const XpressNet::Message& msg = *reinterpret_cast<const XpressNet::Message*>(&lanX.xheader);
   int dataSize = msg.dataSize();
+  if(lanX.xheader == LAN_X_LOCO_INFO)
+  {
+    //Special case for variable length message
+    dataSize = lanX.dataLen() - 6;
+  }
+
   return XpressNet::isChecksumValid(msg, dataSize);
 }
 

--- a/server/src/hardware/protocol/z21/messages.cpp
+++ b/server/src/hardware/protocol/z21/messages.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "messages.hpp"
+#include "../xpressnet/messages.hpp"
 #include "../../decoder/decoder.hpp"
 #include "../../../core/objectproperty.tpp"
 #include "../../../utils/tohex.hpp"
@@ -291,7 +292,21 @@ LanXLocoInfo::LanXLocoInfo(const Decoder& decoder) :
     setSpeedStep(Decoder::throttleToSpeedStep(decoder.throttle, speedSteps()));
   for(const auto &function : *decoder.functions)
     setFunction(function->number, function->value);
-  calcChecksum();
+  updateChecksum();
+}
+
+void LanX::updateChecksum(uint8_t len)
+{
+  uint8_t val = XpressNet::calcChecksum(*reinterpret_cast<const XpressNet::Message*>(&xheader), len);
+  uint8_t* checksum = &xheader + len + 1;
+  *checksum = val;
+}
+
+bool LanX::isChecksumValid(const LanX &lanX)
+{
+  const XpressNet::Message& msg = *reinterpret_cast<const XpressNet::Message*>(&lanX.xheader);
+  int dataSize = msg.dataSize();
+  return XpressNet::isChecksumValid(msg, dataSize);
 }
 
 }

--- a/server/src/hardware/protocol/z21/messages.cpp
+++ b/server/src/hardware/protocol/z21/messages.cpp
@@ -71,7 +71,7 @@ std::string toString(const Message& message, bool raw)
   switch(message.header())
   {
     case LAN_LOGOFF:
-      if(message.dataLen() != sizeof(Z21::LanLogoff))
+      if(message.dataLen() != sizeof(LanLogoff))
         raw = true;
       break;
 
@@ -91,7 +91,7 @@ std::string toString(const Message& message, bool raw)
             raw = true;
           break;
 
-        case 0x53:
+        case LAN_X_SET_TURNOUT:
         {
           const auto& setTurnout = static_cast<const LanXSetTurnout&>(message);
           s = "LAN_X_SET_TURNOUT";
@@ -102,6 +102,7 @@ std::string toString(const Message& message, bool raw)
           s.append(" queue=").append(setTurnout.queue() ? "yes" : "no");
           break;
         }
+
         case LAN_X_BC:
           if(message == LanXBCTrackPowerOff())
             s = "LAN_X_BC_TRACK_POWER_OFF";
@@ -113,7 +114,7 @@ std::string toString(const Message& message, bool raw)
             raw = true;
           break;
 
-        case 0x62:
+        case LAN_X_STATUS_CHANGED:
           if(const LanXStatusChanged& statusChanged = static_cast<const LanXStatusChanged&>(message); statusChanged.db0 == 0x22)
           {
             s = "LAN_X_STATUS_CHANGED";
@@ -140,7 +141,7 @@ std::string toString(const Message& message, bool raw)
             raw = true;
           break;
 
-        case 0xE3:
+        case LAN_X_GET_LOCO_INFO:
           if(const auto& getLocoInfo = static_cast<const LanXGetLocoInfo&>(message); getLocoInfo.db0 == 0xF0)
           {
             s = "LAN_X_GET_LOCO_INFO";
@@ -152,7 +153,7 @@ std::string toString(const Message& message, bool raw)
             raw = true;
           break;
 
-        case 0xE4:
+        case LAN_X_SET_LOCO:
           if(const auto& setLocoDrive = static_cast<const LanXSetLocoDrive&>(message);
               setLocoDrive.db0 >= 0x10 && setLocoDrive.db0 <= 0x13)
           {
@@ -181,7 +182,7 @@ std::string toString(const Message& message, bool raw)
             raw = true;
           break;
 
-        case 0xEF:
+        case LAN_X_LOCO_INFO:
         {
           const auto& locoInfo = static_cast<const LanXLocoInfo&>(message);
           s = "LAN_X_LOCO_INFO";
@@ -199,14 +200,15 @@ std::string toString(const Message& message, bool raw)
           s.append(" busy=").append(locoInfo.isBusy() ? "1" : "0");
           break;
         }
-        case 0xF1:
+
+        case LAN_X_GET_FIRMWARE_VERSION:
           if(message == LanXGetFirmwareVersion())
             s = "LAN_X_GET_FIRMWARE_VERSION";
           else
             raw = true;
           break;
 
-        case 0xF3:
+        case LAN_X_GET_FIRMWARE_VERSION_REPLY:
           if(message.dataLen() == sizeof(LanXGetFirmwareVersionReply))
           {
             const auto& getFirmwareVersion = static_cast<const LanXGetFirmwareVersionReply&>(message);
@@ -237,7 +239,7 @@ std::string toString(const Message& message, bool raw)
       break;
 
     case LAN_SET_BROADCASTFLAGS:
-      if(message.dataLen() == sizeof(Z21::LanSetBroadcastFlags))
+      if(message.dataLen() == sizeof(LanSetBroadcastFlags))
       {
         s = "LAN_SET_BROADCASTFLAGS";
         s.append(" flags=0x").append(toHex(static_cast<std::underlying_type_t<BroadcastFlags>>(static_cast<const LanSetBroadcastFlags&>(message).broadcastFlags())));

--- a/server/src/hardware/protocol/z21/messages.cpp
+++ b/server/src/hardware/protocol/z21/messages.cpp
@@ -301,7 +301,14 @@ void LanX::updateChecksum(uint8_t len)
 {
   uint8_t val = XpressNet::calcChecksum(*reinterpret_cast<const XpressNet::Message*>(&xheader), len);
   uint8_t* checksum = &xheader + len + 1;
+#ifdef __MINGW32__
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
   *checksum = val;
+#ifdef __MINGW32__
+  #pragma GCC diagnostic pop  
+#endif
 }
 
 bool LanX::isChecksumValid(const LanX &lanX)

--- a/server/src/hardware/protocol/z21/messages.hpp
+++ b/server/src/hardware/protocol/z21/messages.hpp
@@ -142,18 +142,37 @@ enum LocoMode : uint8_t
   Motorola = 1,
 };
 
-static constexpr uint8_t LAN_X_SET_STOP = 0x80;
 static constexpr uint8_t LAN_X_TURNOUT_INFO = 0x43;
+static constexpr uint8_t LAN_X_SET_TURNOUT = 0x53;
+
 static constexpr uint8_t LAN_X_BC = 0x61;
+
+static constexpr uint8_t LAN_X_STATUS_CHANGED = 0x62;
+static constexpr uint8_t LAN_X_GET_VERSION_REPLY = 0x63;
+
+//static constexpr uint8_t LAN_X_CV_NACK_SC = 0x12;
+//static constexpr uint8_t LAN_X_CV_NACK = 0x13;
+//static constexpr uint8_t LAN_X_UNKNOWN_COMMAND = 0x82;
+
+static constexpr uint8_t LAN_X_SET_STOP = 0x80;
+static constexpr uint8_t LAN_X_BC_STOPPED = 0x81;
+
+static constexpr uint8_t LAN_X_GET_LOCO_INFO = 0xE3;
+static constexpr uint8_t LAN_X_SET_LOCO = 0xE4;
+static constexpr uint8_t LAN_X_LOCO_INFO = 0xEF;
+
+static constexpr uint8_t LAN_X_GET_FIRMWARE_VERSION = 0xF1;
+static constexpr uint8_t LAN_X_GET_FIRMWARE_VERSION_REPLY = 0xF3;
+
+// db0 for xHeader 0x21
+static constexpr uint8_t LAN_X_SET_TRACK_POWER_OFF = 0x80;
+static constexpr uint8_t LAN_X_SET_TRACK_POWER_ON = 0x81;
+
+// db0 for xHeader LAN_X_BC
 static constexpr uint8_t LAN_X_BC_TRACK_POWER_OFF = 0x00;
 static constexpr uint8_t LAN_X_BC_TRACK_POWER_ON = 0x01;
 //static constexpr uint8_t LAN_X_BC_PROGRAMMING_MODE = 0x02;
 static constexpr uint8_t LAN_X_BC_TRACK_SHORT_CIRCUIT = 0x08;
-//static constexpr uint8_t LAN_X_CV_NACK_SC = 0x12;
-//static constexpr uint8_t LAN_X_CV_NACK = 0x13;
-//static constexpr uint8_t LAN_X_UNKNOWN_COMMAND = 0x82;
-static constexpr uint8_t LAN_X_BC_STOPPED = 0x81;
-static constexpr uint8_t LAN_X_LOCO_INFO = 0xEF;
 
 enum HardwareType : uint32_t
 {
@@ -332,7 +351,7 @@ struct LanXGetFirmwareVersion : LanX
   uint8_t checksum = 0xFB;
 
   LanXGetFirmwareVersion() :
-    LanX(sizeof(LanXGetFirmwareVersion), 0xF1)
+    LanX(sizeof(LanXGetFirmwareVersion), LAN_X_GET_FIRMWARE_VERSION)
   {
   }
 } ATTRIBUTE_PACKED;
@@ -354,7 +373,7 @@ static_assert(sizeof(LanXGetStatus) == 7);
 // LAN_X_SET_TRACK_POWER_OFF
 struct LanXSetTrackPowerOff : LanX
 {
-  uint8_t db0 = 0x80;
+  uint8_t db0 = LAN_X_SET_TRACK_POWER_OFF;
   uint8_t checksum = 0xa1;
 
   LanXSetTrackPowerOff() :
@@ -367,7 +386,7 @@ static_assert(sizeof(LanXSetTrackPowerOff) == 7);
 // LAN_X_SET_TRACK_POWER_ON
 struct LanXSetTrackPowerOn : LanX
 {
-  uint8_t db0 = 0x81;
+  uint8_t db0 = LAN_X_SET_TRACK_POWER_OFF;
   uint8_t checksum = 0xa0;
 
   LanXSetTrackPowerOn() :
@@ -422,7 +441,7 @@ struct LanXSetTurnout : LanX
   uint8_t checksum;
 
   LanXSetTurnout(uint16_t linearAddress, bool activate, bool queue = false)
-    : LanX(sizeof(LanXSetTurnout), 0x53)
+    : LanX(sizeof(LanXSetTurnout), LAN_X_SET_TURNOUT)
     , db0(linearAddress >> 9)
     , db1((linearAddress >> 1) & 0xFF)
   {
@@ -484,7 +503,7 @@ struct LanXGetLocoInfo : LanX
   uint8_t checksum;
 
   LanXGetLocoInfo(uint16_t address, bool longAddress) :
-    LanX(sizeof(LanXGetLocoInfo),  0xE3)
+    LanX(sizeof(LanXGetLocoInfo), LAN_X_GET_LOCO_INFO)
   {
     setAddress(address, longAddress);
     updateChecksum();
@@ -518,7 +537,7 @@ struct LanXSetLocoDrive : LanX
   uint8_t checksum;
 
   LanXSetLocoDrive() :
-    LanX(sizeof(LanXSetLocoDrive), 0xE4)
+    LanX(sizeof(LanXSetLocoDrive), LAN_X_SET_LOCO)
   {
   }
 
@@ -623,7 +642,7 @@ struct LanXSetLocoFunction : LanX
   uint8_t checksum;
 
   LanXSetLocoFunction() :
-    LanX(sizeof(LanXSetLocoFunction), 0xE4)
+    LanX(sizeof(LanXSetLocoFunction), LAN_X_SET_LOCO)
   {
   }
 
@@ -909,7 +928,7 @@ struct LanXGetVersionReply : LanX
   uint8_t checksum;
 
   LanXGetVersionReply()
-    : LanX(sizeof(LanXGetVersionReply), 0x63)
+    : LanX(sizeof(LanXGetVersionReply), LAN_X_GET_VERSION_REPLY)
   {
   }
 
@@ -945,7 +964,7 @@ struct LanXGetFirmwareVersionReply : LanX
   uint8_t checksum;
 
   LanXGetFirmwareVersionReply() :
-    LanX(sizeof(LanXGetFirmwareVersionReply), 0xF3)
+    LanX(sizeof(LanXGetFirmwareVersionReply), LAN_X_GET_FIRMWARE_VERSION_REPLY)
   {
   }
 
@@ -1068,7 +1087,7 @@ struct LanXStatusChanged : LanX
   uint8_t checksum;
 
   LanXStatusChanged() :
-    LanX(sizeof(LanXStatusChanged), 0x62)
+    LanX(sizeof(LanXStatusChanged), LAN_X_STATUS_CHANGED)
   {
   }
 } ATTRIBUTE_PACKED;

--- a/server/src/hardware/protocol/z21/messages.hpp
+++ b/server/src/hardware/protocol/z21/messages.hpp
@@ -546,6 +546,24 @@ struct LanXSetLocoDrive : LanX
     addressLow = longAddress ? address & 0xFF : address & 0x7F;
   }
 
+  inline void setSpeedSteps(uint8_t steps)
+  {
+    switch(steps)
+    {
+    case 14:
+      db0 = 0x10;
+      break;
+    case 28:
+      db0 = 0x12;
+      break;
+    case 126:
+    case 128:
+    default:
+      db0 = 0x13;
+      break;
+    }
+  }
+
   inline uint8_t speedSteps() const
   {
     switch(db0 & 0x0F)

--- a/server/src/hardware/protocol/z21/messages.hpp
+++ b/server/src/hardware/protocol/z21/messages.hpp
@@ -1104,14 +1104,14 @@ struct LanXLocoInfo : LanX
   static constexpr uint8_t flagF0 = 0x10;
   static constexpr uint8_t functionIndexMax = 28;
 
-  uint8_t addressHigh = 0;
-  uint8_t addressLow = 0;
+  uint8_t addressHigh = 0; //db0
+  uint8_t addressLow = 0;  //db1
   uint8_t db2 = 0;
-  uint8_t speedAndDirection = 0;
+  uint8_t speedAndDirection = 0; //db3
   uint8_t db4 = 0;
-  uint8_t f5f12 = 0;
-  uint8_t f13f20 = 0;
-  uint8_t f21f28 = 0;
+  uint8_t f5f12 = 0;    //db5
+  uint8_t f13f20 = 0;   //db6
+  uint8_t f21f28 = 0;   //db7
   uint8_t checksum = 0;
 
   LanXLocoInfo() :
@@ -1263,11 +1263,10 @@ struct LanXLocoInfo : LanX
     }
   }
 
-  void updateChecksum()
+  inline void updateChecksum()
   {
-    checksum = xheader;
-    for(uint8_t* db = &addressHigh; db < &checksum; db++)
-      checksum ^= *db;
+    //Data length - 7 Z21 header bytes + 1 byte for db0
+    LanX::updateChecksum(dataLen() - 6);
   }
 } ATTRIBUTE_PACKED;
 static_assert(sizeof(LanXLocoInfo) == 14);

--- a/server/src/hardware/protocol/z21/serverkernel.cpp
+++ b/server/src/hardware/protocol/z21/serverkernel.cpp
@@ -109,7 +109,7 @@ void ServerKernel::receiveFrom(const Message& message, IOHandler::ClientId clien
               response.db1 |= Z21_CENTRALSTATE_EMERGENCYSTOP;
             if(m_trackPowerOn != TriState::True)
               response.db1 |= Z21_CENTRALSTATE_TRACKVOLTAGEOFF;
-            response.calcChecksum();
+            response.updateChecksum();
             sendTo(response, clientId);
           }
           else if(message == LanXSetTrackPowerOn())

--- a/server/src/hardware/protocol/z21/serverkernel.cpp
+++ b/server/src/hardware/protocol/z21/serverkernel.cpp
@@ -150,7 +150,7 @@ void ServerKernel::receiveFrom(const Message& message, IOHandler::ClientId clien
           }
           break;
 
-        case 0xE3:
+        case LAN_X_GET_LOCO_INFO:
           if(const auto& getLocoInfo = static_cast<const LanXGetLocoInfo&>(message);
               getLocoInfo.db0 == 0xF0)
           {
@@ -165,7 +165,7 @@ void ServerKernel::receiveFrom(const Message& message, IOHandler::ClientId clien
           }
           break;
 
-        case 0xE4:
+        case LAN_X_SET_LOCO:
           if(const auto& setLocoDrive = static_cast<const LanXSetLocoDrive&>(message);
               setLocoDrive.db0 >= 0x10 && setLocoDrive.db0 <= 0x13)
           {
@@ -221,7 +221,7 @@ void ServerKernel::receiveFrom(const Message& message, IOHandler::ClientId clien
           }
           break;
 
-        case 0xF1:
+        case LAN_X_GET_FIRMWARE_VERSION:
           if(message == LanXGetFirmwareVersion())
             sendTo(LanXGetFirmwareVersionReply(ServerConfig::firmwareVersionMajor, ServerConfig::firmwareVersionMinor), clientId);
           break;

--- a/server/src/hardware/protocol/z21/utils.hpp
+++ b/server/src/hardware/protocol/z21/utils.hpp
@@ -61,7 +61,7 @@ constexpr bool isEmergencyStop(uint8_t db, uint8_t speedSteps)
 
 constexpr void setEmergencyStop(uint8_t& db)
 {
-  db = (db & directionFlag) | 0x01;
+  db = (db & directionFlag) | 0x01; // preserve direction flag
 }
 
 constexpr uint8_t getSpeedStep(uint8_t db, uint8_t speedSteps)
@@ -77,6 +77,8 @@ constexpr uint8_t getSpeedStep(uint8_t db, uint8_t speedSteps)
 
     case 28:
       db = ((db & 0x0F) << 1) | ((db & 0x10) >> 4); //! @todo check
+      if(db >= 3)
+          db -= 2;
       break;
 
     case 14:
@@ -86,7 +88,7 @@ constexpr uint8_t getSpeedStep(uint8_t db, uint8_t speedSteps)
     default:
       return 0;
   }
-  return db > 1 ? db - 1 : 0; // step 1 = EStop
+  return db >= 1 ? db - 1 : 0; // step 1 = EStop
 }
 
 constexpr void setSpeedStep(uint8_t& db, uint8_t speedSteps, uint8_t speedStep)
@@ -100,7 +102,8 @@ constexpr void setSpeedStep(uint8_t& db, uint8_t speedSteps, uint8_t speedStep)
         break;
 
       case 28:
-        db |= ((speedStep >> 1) & 0x0F) | ((speedStep << 4) & 0x01);
+        speedStep += 2;
+        db |= ((speedStep >> 1) & 0x0F) | ((speedStep & 0x01) << 4);
         break;
 
       case 14:


### PR DESCRIPTION
Hi! These changes are extracted from other PRs, mainly #59 and #73, #56 and do not change behavior except bug fixing.

- d9ace24d88c32cd768a6e93ee4e17280558803b2 First commit is a short term solution to #53 but can also be kept afterwards as it's better to capture as less as possible.
- 0e463ff8fe97889b0921bda4b519e8f28058d2ce Can be explained a bit better, test if you run in race condition by connecting station in a different world state than Traintastic and see who imposes it's state on the other.
- b48e8f75069e79d5c3e021e3d52c795c89f028a4 Double check format is now correct
- 488663331dbbc002491a8d9c5a72799659f3f85e There are still other hardcoded values in `simulationiohandler.cpp` and `serverkernel.cpp` which can be labelled but didn't know what names to give them.
