### PR TITLE
Z21 handle loco info 2

### DIFF
--- a/server/src/hardware/decoder/decoderchangeflags.hpp
+++ b/server/src/hardware/decoder/decoderchangeflags.hpp
@@ -40,6 +40,11 @@ constexpr DecoderChangeFlags operator| (const DecoderChangeFlags& lhs, const Dec
   return static_cast<DecoderChangeFlags>(static_cast<std::underlying_type_t<DecoderChangeFlags>>(lhs) | static_cast<std::underlying_type_t<DecoderChangeFlags>>(rhs));
 }
 
+constexpr void operator|= (DecoderChangeFlags& lhs, const DecoderChangeFlags& rhs)
+{
+  lhs = lhs | rhs;
+}
+
 constexpr bool has(const DecoderChangeFlags& value, const DecoderChangeFlags& mask)
 {
   return (static_cast<std::underlying_type_t<DecoderChangeFlags>>(value) & static_cast<std::underlying_type_t<DecoderChangeFlags>>(mask)) != 0;

--- a/server/src/hardware/protocol/z21/clientkernel.cpp
+++ b/server/src/hardware/protocol/z21/clientkernel.cpp
@@ -121,10 +121,11 @@ void ClientKernel::receive(const Message& message)
           {
             const auto& reply = static_cast<const LanXLocoInfo&>(message);
 
-            const int maxFunc = reply.supportsF29F31() ? 31 : 28;
-            bool val[31 + 1] = {};
+            //NOTE: there is also a function at index 0, hence +1
+            const int functionIndexMax = std::min(reply.functionIndexMax(), LanXLocoInfo::supportedFunctionIndexMax);
+            bool val[LanXLocoInfo::supportedFunctionIndexMax + 1] = {};
 
-            for(int i = 0; i <= maxFunc; i++)
+            for(int i = 0; i <= functionIndexMax; i++)
             {
               val[i] = reply.getFunction(i);
             }
@@ -231,7 +232,7 @@ void ClientKernel::receive(const Message& message)
             EventLoop::call(
               [this, address=reply.address(), isEStop=reply.isEmergencyStop(),
               speed = reply.speedStep(), speedMax=reply.speedSteps(),
-              dir = reply.direction(), val, maxFunc, changes]()
+              dir = reply.direction(), val, functionIndexMax, changes]()
               {
                 try
                 {
@@ -262,7 +263,7 @@ void ClientKernel::receive(const Message& message)
 
                     //Function get always updated because we do not store a copy in cache
                     //so there is no way to tell in advance if they changed
-                    for(int i = 0; i <= maxFunc; i++)
+                    for(int i = 0; i <= functionIndexMax; i++)
                     {
                       decoder->setFunctionValue(i, val[i]);
                     }

--- a/server/src/hardware/protocol/z21/clientkernel.cpp
+++ b/server/src/hardware/protocol/z21/clientkernel.cpp
@@ -133,19 +133,26 @@ void ClientKernel::receive(const Message& message)
               speed = reply.speedStep(), speedMax=reply.speedSteps(),
               dir = reply.direction(), val, maxFunc]()
               {
-                if(auto decoder = m_decoderController->getDecoder(DCC::getProtocol(address), address))
+                try
                 {
-                  float throttle = Decoder::speedStepToThrottle(speed, speedMax);
-
-                  decoder->emergencyStop = isEStop;
-                  decoder->direction = dir;
-
-                  decoder->throttle = throttle;
-
-                  for(int i = 0; i <= maxFunc; i++)
+                  if(auto decoder = m_decoderController->getDecoder(DCC::getProtocol(address), address))
                   {
-                    decoder->setFunctionValue(i, val[i]);
+                    float throttle = Decoder::speedStepToThrottle(speed, speedMax);
+
+                    decoder->emergencyStop = isEStop;
+                    decoder->direction = dir;
+
+                    decoder->throttle = throttle;
+
+                    for(int i = 0; i <= maxFunc; i++)
+                    {
+                      decoder->setFunctionValue(i, val[i]);
+                    }
                   }
+                }
+                catch(...)
+                {
+
                 }
               });
           }

--- a/server/src/hardware/protocol/z21/clientkernel.cpp
+++ b/server/src/hardware/protocol/z21/clientkernel.cpp
@@ -241,24 +241,24 @@ void ClientKernel::receive(const Message& message)
 
                     if(has(changes, DecoderChangeFlags::EmergencyStop))
                     {
-                      isUpdatingDecoderFromKernel = true;
+                      m_isUpdatingDecoderFromKernel = true;
                       decoder->emergencyStop = isEStop;
                     }
 
                     if(has(changes, DecoderChangeFlags::Direction))
                     {
-                      isUpdatingDecoderFromKernel = true;
+                      m_isUpdatingDecoderFromKernel = true;
                       decoder->direction = dir;
                     }
 
                     if(has(changes, DecoderChangeFlags::Throttle | DecoderChangeFlags::SpeedSteps))
                     {
-                      isUpdatingDecoderFromKernel = true;
+                      m_isUpdatingDecoderFromKernel = true;
                       decoder->throttle = throttle;
                     }
 
                     //Reset flag guard at end
-                    isUpdatingDecoderFromKernel = false;
+                    m_isUpdatingDecoderFromKernel = false;
 
                     //Function get always updated because we do not store a copy in cache
                     //so there is no way to tell in advance if they changed
@@ -504,7 +504,7 @@ void ClientKernel::decoderChanged(const Decoder& decoder, DecoderChangeFlags cha
   if(const auto& f = decoder.getFunction(functionNumber))
     funcVal = toTriState(f->value);
 
-  if(isUpdatingDecoderFromKernel)
+  if(m_isUpdatingDecoderFromKernel)
   {
     //This change was caused by Z21 message so there is not point
     //on informing back Z21 with another message
@@ -512,7 +512,7 @@ void ClientKernel::decoderChanged(const Decoder& decoder, DecoderChangeFlags cha
     //at a new value (EventLoop is slower to process callbacks)
     //But reset the guard to allow Train and other parts of code
     //to react to this change and further edit decoder state
-    isUpdatingDecoderFromKernel = false;
+    m_isUpdatingDecoderFromKernel = false;
     return;
   }
 

--- a/server/src/hardware/protocol/z21/clientkernel.cpp
+++ b/server/src/hardware/protocol/z21/clientkernel.cpp
@@ -493,8 +493,8 @@ void ClientKernel::emergencyStop()
 
 void ClientKernel::decoderChanged(const Decoder& decoder, DecoderChangeFlags changes, uint32_t functionNumber)
 {
-  const uint16_t addr = decoder.address;
-  const bool longAddr = decoder.protocol == DecoderProtocol::DCCLong;
+  const uint16_t address = decoder.address;
+  const bool longAddress = decoder.protocol == DecoderProtocol::DCCLong;
 
   const Direction direction = decoder.direction;
   const float throttle = decoder.throttle;
@@ -517,10 +517,10 @@ void ClientKernel::decoderChanged(const Decoder& decoder, DecoderChangeFlags cha
     return;
   }
 
-  m_ioContext.post([this, addr, longAddr, direction, throttle, speedSteps, isEStop, changes, functionNumber, funcVal]()
+  m_ioContext.post([this, address, longAddress, direction, throttle, speedSteps, isEStop, changes, functionNumber, funcVal]()
     {
       LanXSetLocoDrive cmd;
-      cmd.setAddress(addr, longAddr);
+      cmd.setAddress(address, longAddress);
 
       cmd.setSpeedSteps(speedSteps);
       int speedStep = Decoder::throttleToSpeedStep(throttle, cmd.speedSteps());
@@ -530,7 +530,7 @@ void ClientKernel::decoderChanged(const Decoder& decoder, DecoderChangeFlags cha
       cmd.setSpeedStep(speedStep);
       cmd.setDirection(direction);
 
-      LocoCache &cache = getLocoCache(addr);
+      LocoCache &cache = getLocoCache(address);
 
       bool changed = false;
       if(has(changes, DecoderChangeFlags::Direction) && cache.direction != direction)
@@ -559,7 +559,7 @@ void ClientKernel::decoderChanged(const Decoder& decoder, DecoderChangeFlags cha
         if(functionNumber <= LanXSetLocoFunction::functionNumberMax && funcVal != TriState::Undefined)
         {
           send(LanXSetLocoFunction(
-            addr, longAddr,
+            address, longAddress,
             static_cast<uint8_t>(functionNumber),
             funcVal == TriState::True ? LanXSetLocoFunction::SwitchType::On : LanXSetLocoFunction::SwitchType::Off));
         }

--- a/server/src/hardware/protocol/z21/clientkernel.cpp
+++ b/server/src/hardware/protocol/z21/clientkernel.cpp
@@ -133,6 +133,26 @@ void ClientKernel::receive(const Message& message)
 
             DecoderChangeFlags changes = DecoderChangeFlags(0);
 
+            //Rescale everything to 126 steps
+            int currentSpeedStep = reply.speedStep();
+            if(reply.speedSteps() != 126)
+            {
+              currentSpeedStep = float(currentSpeedStep) / float(reply.speedSteps()) * 126.0;
+              if(abs(currentSpeedStep - cache->lastReceivedSpeedStep) < 5)
+                currentSpeedStep = cache->lastReceivedSpeedStep; //Consider it a rounding error
+            }
+
+            int targetSpeedStep = cache->speedStep;
+            if(cache->speedSteps != 126)
+            {
+              targetSpeedStep = float(targetSpeedStep) / float(cache->speedSteps) * 126.0;
+            }
+
+            if(cache->lastReceivedSpeedStep <= currentSpeedStep)
+              cache->speedTrend = LocoCache::Trend::Ascending;
+            else
+              cache->speedTrend = LocoCache::Trend::Descending;
+
             if(reply.speedSteps() != cache->speedSteps || reply.speedStep() != cache->speedStep)
             {
               // Use a timeout of 1 second to prevent reacting to Z21 feedback messages
@@ -146,7 +166,7 @@ void ClientKernel::receive(const Message& message)
               // (100ms) because values will be refreshed and timeout restarted by Train itself
               // but we need to accout also for network trasmission and Z21 processing time.
 
-              if((std::chrono::steady_clock::now() - cache->lastSetTime) > std::chrono::seconds(1))
+              if((std::chrono::steady_clock::now() - cache->lastSetTime) > std::chrono::milliseconds(1000))
               {
                 if(reply.speedSteps() != cache->speedSteps)
                 {
@@ -159,6 +179,26 @@ void ClientKernel::receive(const Message& message)
 
                 cache->speedSteps = reply.speedSteps();
                 cache->speedStep = reply.speedStep();
+              }
+              else
+              {
+                bool maybeOldFeedback = false;
+
+                if((cache->speedTrend == LocoCache::Trend::Ascending && currentSpeedStep <= targetSpeedStep)
+                    || (cache->speedTrend == LocoCache::Trend::Descending && currentSpeedStep >= targetSpeedStep))
+                {
+                  //When accelerating or decelerating ignore all speeds between original speed and target speed.
+                  //These messages are probably feedback of our own changes arrived with some delay.
+                  //If we get values outside this range or changing trend we pass them to let Train adjust.
+                  maybeOldFeedback = true;
+                }
+
+                if(!maybeOldFeedback)
+                {
+                  changes |= DecoderChangeFlags::Throttle | DecoderChangeFlags::SpeedSteps;
+                  cache->speedSteps = reply.speedSteps();
+                  cache->speedStep = reply.speedStep();
+                }
               }
             }
 
@@ -180,6 +220,8 @@ void ClientKernel::receive(const Message& message)
             }
 
             //Do not update last seen time to avoid ignoring genuine user commands
+            //Store last received speed step converted to 126 steps scale
+            cache->lastReceivedSpeedStep = currentSpeedStep;
 
             EventLoop::call(
               [this, address=reply.address(), isEStop=reply.isEmergencyStop(),
@@ -517,6 +559,19 @@ void ClientKernel::decoderChanged(const Decoder& decoder, DecoderChangeFlags cha
         }
       }
 
+      //Rescale everything to 126 steps
+      int oldTargetSpeedStep = cache->speedStep;
+      if(cache->speedSteps != 126)
+      {
+        oldTargetSpeedStep = float(oldTargetSpeedStep) / float(cache->speedSteps) * 126.0;
+      }
+
+      int newTargetSpeedStep = cmd.speedStep();
+      if(cmd.speedSteps() != 126)
+      {
+        newTargetSpeedStep = float(newTargetSpeedStep) / float(cmd.speedSteps()) * 126.0;
+      }
+
       if(changed)
       {
         cache->speedSteps = cmd.speedSteps();
@@ -524,11 +579,27 @@ void ClientKernel::decoderChanged(const Decoder& decoder, DecoderChangeFlags cha
         cache->direction = cmd.direction();
         cache->isEStop = cmd.isEmergencyStop();
 
+        if(newTargetSpeedStep >= oldTargetSpeedStep)
+        {
+          cache->speedTrend = LocoCache::Trend::Ascending;
+          if(cache->lastReceivedSpeedStep > newTargetSpeedStep)
+            cache->lastReceivedSpeedStep = 0; //Reset to minimum
+        }
+        else
+        {
+          cache->speedTrend = LocoCache::Trend::Descending;
+          if(cache->lastReceivedSpeedStep < newTargetSpeedStep)
+            cache->lastReceivedSpeedStep = 126; //Reset to maximum
+        }
+
         //Update last seen time to ignore feedback messages of our own changes
         //This potentially ignores also user commands coming from Z21 if issued
-        //In less than 2 seconds from now
+        //In less than 1 seconds from now
         cache->lastSetTime = std::chrono::steady_clock::now();
+      }
 
+      if(changed)
+      {
         cmd.updateChecksum();
         send(cmd);
       }

--- a/server/src/hardware/protocol/z21/clientkernel.cpp
+++ b/server/src/hardware/protocol/z21/clientkernel.cpp
@@ -131,39 +131,60 @@ void ClientKernel::receive(const Message& message)
 
             LocoCache *cache = getLocoCache(reply.address());
 
-            bool changed = false;
-            if(reply.isEmergencyStop() || (std::chrono::steady_clock::now() - cache->lastSetTime) > std::chrono::seconds(2))
+            DecoderChangeFlags changes = DecoderChangeFlags(0);
+
+            if(reply.speedSteps() != cache->speedSteps || reply.speedStep() != cache->speedStep)
             {
-              if(reply.speedSteps() != cache->speedSteps)
+              // Use a timeout of 1 second to prevent reacting to Z21 feedback messages
+              // of our own changes. This would be problematic because in the meatime our
+              // changes were sent to Z21 processed and received back here, decoder state
+              // might have changed (and sent again to Z21) so we should discard "old" state.
+              // This has the potential of ignoring genuine user changes for this decoder
+              // (made by a physical throttle or other hardware connected to Z21) but
+              // being the timeout short it should rarely happen.
+              // Theoretically the timeout should only be of Train::updateSpeed() timer timeout
+              // (100ms) because values will be refreshed and timeout restarted by Train itself
+              // but we need to accout also for network trasmission and Z21 processing time.
+
+              if((std::chrono::steady_clock::now() - cache->lastSetTime) > std::chrono::seconds(1))
               {
+                if(reply.speedSteps() != cache->speedSteps)
+                {
+                  changes |= DecoderChangeFlags::SpeedSteps;
+                }
+                if(reply.speedStep() != cache->speedStep)
+                {
+                  changes |= DecoderChangeFlags::Throttle;
+                }
+
                 cache->speedSteps = reply.speedSteps();
                 cache->speedStep = reply.speedStep();
-                cache->direction = reply.direction();
-                changed = true;
               }
-              else if(reply.speedStep() != cache->speedStep || reply.direction() != cache->direction)
-              {
-                if((std::chrono::steady_clock::now() - cache->lastSetTime) > std::chrono::seconds(2))
-                {
-                  cache->speedStep = reply.speedStep();
-                  cache->direction = reply.direction();
-                  changed = true;
-                }
-              }
-
-              if(reply.isEmergencyStop() != cache->isEStop)
-              {
-                cache->isEStop = reply.isEmergencyStop();
-                changed = true;
-              }
-
-              //Do not update last seen time to avoid ignoring genuine user commands
             }
+
+            //Emergency stop is urgent so bypass timeout
+            //Direction is not propagated back so it shouldn't start looping
+            //We bypass timeout also for Direction change.
+            //It can at worst cause a short flickering changing direction n times and then settle down
+            if(reply.direction() != cache->direction)
+            {
+              changes |= DecoderChangeFlags::Direction;
+              cache->direction = reply.direction();
+            }
+            if(reply.isEmergencyStop() || reply.isEmergencyStop() != cache->isEStop)
+            {
+              //Force change when emergency stop is set to be sure it gets received
+              //as soon as possible
+              changes |= DecoderChangeFlags::EmergencyStop;
+              cache->isEStop = reply.isEmergencyStop();
+            }
+
+            //Do not update last seen time to avoid ignoring genuine user commands
 
             EventLoop::call(
               [this, address=reply.address(), isEStop=reply.isEmergencyStop(),
               speed = reply.speedStep(), speedMax=reply.speedSteps(),
-              dir = reply.direction(), val, maxFunc, changed]()
+              dir = reply.direction(), val, maxFunc, changes]()
               {
                 try
                 {
@@ -171,22 +192,29 @@ void ClientKernel::receive(const Message& message)
                   {
                     float throttle = Decoder::speedStepToThrottle(speed, speedMax);
 
-                    if(changed)
+                    if(has(changes, DecoderChangeFlags::EmergencyStop))
                     {
-                      //Set the bool guard for each change
                       isUpdatingDecoderFromKernel = true;
                       decoder->emergencyStop = isEStop;
-
-                      isUpdatingDecoderFromKernel = true;
-                      decoder->direction = dir;
-
-                      isUpdatingDecoderFromKernel = true;
-                      decoder->throttle = throttle;
-
-                      //Reset at end
-                      isUpdatingDecoderFromKernel = false;
                     }
 
+                    if(has(changes, DecoderChangeFlags::Direction))
+                    {
+                      isUpdatingDecoderFromKernel = true;
+                      decoder->direction = dir;
+                    }
+
+                    if(has(changes, DecoderChangeFlags::Throttle | DecoderChangeFlags::SpeedSteps))
+                    {
+                      isUpdatingDecoderFromKernel = true;
+                      decoder->throttle = throttle;
+                    }
+
+                    //Reset flag guard at end
+                    isUpdatingDecoderFromKernel = false;
+
+                    //Function get always updated because we do not store a copy in cache
+                    //so there is no way to tell in advance if they changed
                     for(int i = 0; i <= maxFunc; i++)
                     {
                       decoder->setFunctionValue(i, val[i]);

--- a/server/src/hardware/protocol/z21/clientkernel.cpp
+++ b/server/src/hardware/protocol/z21/clientkernel.cpp
@@ -116,13 +116,13 @@ void ClientKernel::receive(const Message& message)
 
         case LAN_X_LOCO_INFO:
         {
-          const int n = message.dataLen() - 7;
-          if(n >= 7 && n <= 14)
+          if(message.dataLen() >= LanXLocoInfo::minMessageSize && message.dataLen() <= LanXLocoInfo::maxMessageSize)
           {
             const auto& reply = static_cast<const LanXLocoInfo&>(message);
 
+            const int maxFunc = reply.supportsF29F31() ? 31 : 28;
             bool val[31 + 1] = {};
-            const int maxFunc = (n >= 8) ? 31 : 28;
+
             for(int i = 0; i <= maxFunc; i++)
             {
               val[i] = reply.getFunction(i);

--- a/server/src/hardware/protocol/z21/clientkernel.cpp
+++ b/server/src/hardware/protocol/z21/clientkernel.cpp
@@ -24,6 +24,7 @@
 #include "messages.hpp"
 #include "../../decoder/decoder.hpp"
 #include "../../decoder/decoderchangeflags.hpp"
+#include "../../protocol/dcc/dcc.hpp"
 #include "../../input/inputcontroller.hpp"
 #include "../../../core/eventloop.hpp"
 #include "../../../log/log.hpp"
@@ -112,6 +113,44 @@ void ClientKernel::receive(const Message& message)
               });
           }
           break;
+
+        case LAN_X_LOCO_INFO:
+        {
+          const int n = message.dataLen() - 7;
+          if(n >= 7 && n <= 14)
+          {
+            const auto& reply = static_cast<const LanXLocoInfo&>(message);
+
+            bool val[31 + 1] = {};
+            const int maxFunc = (n >= 8) ? 31 : 28;
+            for(int i = 0; i <= maxFunc; i++)
+            {
+              val[i] = reply.getFunction(i);
+            }
+
+            EventLoop::call(
+              [this, address=reply.address(), isEStop=reply.isEmergencyStop(),
+              speed = reply.speedStep(), speedMax=reply.speedSteps(),
+              dir = reply.direction(), val, maxFunc]()
+              {
+                if(auto decoder = m_decoderController->getDecoder(DCC::getProtocol(address), address))
+                {
+                  float throttle = Decoder::speedStepToThrottle(speed, speedMax);
+
+                  decoder->emergencyStop = isEStop;
+                  decoder->direction = dir;
+
+                  decoder->throttle = throttle;
+
+                  for(int i = 0; i <= maxFunc; i++)
+                  {
+                    decoder->setFunctionValue(i, val[i]);
+                  }
+                }
+              });
+          }
+          break;
+        }
       }
       break;
     }

--- a/server/src/hardware/protocol/z21/clientkernel.cpp
+++ b/server/src/hardware/protocol/z21/clientkernel.cpp
@@ -148,10 +148,15 @@ void ClientKernel::receive(const Message& message)
               targetSpeedStep = float(targetSpeedStep) / float(cache->speedSteps) * 126.0;
             }
 
-            if(cache->lastReceivedSpeedStep <= currentSpeedStep)
-              cache->speedTrend = LocoCache::Trend::Ascending;
-            else
-              cache->speedTrend = LocoCache::Trend::Descending;
+            if(!cache->speedTrendExplicitlySet)
+            {
+              //Calculate new speed trend
+              if(cache->lastReceivedSpeedStep <= currentSpeedStep)
+                cache->speedTrend = LocoCache::Trend::Ascending;
+              else
+                cache->speedTrend = LocoCache::Trend::Descending;
+            }
+            cache->speedTrendExplicitlySet = false;
 
             if(reply.speedSteps() != cache->speedSteps || reply.speedStep() != cache->speedStep)
             {
@@ -591,6 +596,7 @@ void ClientKernel::decoderChanged(const Decoder& decoder, DecoderChangeFlags cha
           if(cache->lastReceivedSpeedStep < newTargetSpeedStep)
             cache->lastReceivedSpeedStep = 126; //Reset to maximum
         }
+        cache->speedTrendExplicitlySet = true;
 
         //Update last seen time to ignore feedback messages of our own changes
         //This potentially ignores also user commands coming from Z21 if issued

--- a/server/src/hardware/protocol/z21/clientkernel.cpp
+++ b/server/src/hardware/protocol/z21/clientkernel.cpp
@@ -173,9 +173,18 @@ void ClientKernel::receive(const Message& message)
 
                     if(changed)
                     {
+                      //Set the bool guard for each change
+                      isUpdatingDecoderFromKernel = true;
                       decoder->emergencyStop = isEStop;
+
+                      isUpdatingDecoderFromKernel = true;
                       decoder->direction = dir;
+
+                      isUpdatingDecoderFromKernel = true;
                       decoder->throttle = throttle;
+
+                      //Reset at end
+                      isUpdatingDecoderFromKernel = false;
                     }
 
                     for(int i = 0; i <= maxFunc; i++)
@@ -420,10 +429,23 @@ void ClientKernel::decoderChanged(const Decoder& decoder, DecoderChangeFlags cha
   if(const auto& f = decoder.getFunction(functionNumber))
     funcVal = toTriState(f->value);
 
+  if(isUpdatingDecoderFromKernel)
+  {
+    //This change was caused by Z21 message so there is not point
+    //on informing back Z21 with another message
+    //Skip updating LocoCache again which might already be
+    //at a new value (EventLoop is slower to process callbacks)
+    //But reset the guard to allow Train and other parts of code
+    //to react to this change and further edit decoder state
+    isUpdatingDecoderFromKernel = false;
+    return;
+  }
+
   m_ioContext.post([this, addr, longAddr, direction, throttle, speedSteps, isEStop, changes, functionNumber, funcVal]()
     {
       LanXSetLocoDrive cmd;
       cmd.setAddress(addr, longAddr);
+
       cmd.setSpeedSteps(speedSteps);
       int speedStep = Decoder::throttleToSpeedStep(throttle, cmd.speedSteps());
 

--- a/server/src/hardware/protocol/z21/clientkernel.hpp
+++ b/server/src/hardware/protocol/z21/clientkernel.hpp
@@ -161,7 +161,8 @@ class ClientKernel final : public Kernel
     void startInactiveDecoderPurgeTimer();
     void inactiveDecoderPurgeTimerExpired(const boost::system::error_code &ec);
 
-    LocoCache *getLocoCache(uint16_t dccAddr);
+    LocoCache &getLocoCache(uint16_t dccAddr);
+
 public:
     /**
      * @brief Create kernel and IO handler

--- a/server/src/hardware/protocol/z21/clientkernel.hpp
+++ b/server/src/hardware/protocol/z21/clientkernel.hpp
@@ -87,7 +87,7 @@ class ClientKernel final : public Kernel
     /*!
      * \brief m_trackPowerOn caches command station track power state.
      *
-     * NOTE: it must be accessed only from event loop thread or from
+     * \note It must be accessed only from event loop thread or from
      * Z21::ClientKernel::onStart().
      *
      * \sa EventLoop
@@ -97,7 +97,7 @@ class ClientKernel final : public Kernel
     /*!
      * \brief m_emergencyStop caches command station emergency stop state.
      *
-     * NOTE: it must be accessed only from event loop thread or from
+     * \note It must be accessed only from event loop thread or from
      * Z21::ClientKernel::onStart().
      *
      * \sa EventLoop

--- a/server/src/hardware/protocol/z21/clientkernel.hpp
+++ b/server/src/hardware/protocol/z21/clientkernel.hpp
@@ -110,10 +110,18 @@ class ClientKernel final : public Kernel
 
     struct LocoCache
     {
+      enum class Trend : bool
+      {
+          Ascending = 0,
+          Descending
+      };
+
       uint16_t dccAddress = 0;
+      bool isEStop = false;
       uint8_t speedStep = 0;
       uint8_t speedSteps = 0;
-      bool isEStop = false;
+      uint8_t lastReceivedSpeedStep = 0; //Always in 126 steps
+      Trend speedTrend = Trend::Ascending;
       Direction direction = Direction::Unknown;
       std::chrono::steady_clock::time_point lastSetTime;
     };

--- a/server/src/hardware/protocol/z21/clientkernel.hpp
+++ b/server/src/hardware/protocol/z21/clientkernel.hpp
@@ -119,6 +119,7 @@ class ClientKernel final : public Kernel
     };
 
     std::unordered_map<uint16_t, LocoCache> m_locoCache;
+    bool isUpdatingDecoderFromKernel = false;
 
     InputController* m_inputController = nullptr;
     std::array<TriState, rbusAddressMax - rbusAddressMin + 1> m_rbusFeedbackStatus;

--- a/server/src/hardware/protocol/z21/clientkernel.hpp
+++ b/server/src/hardware/protocol/z21/clientkernel.hpp
@@ -128,7 +128,7 @@ class ClientKernel final : public Kernel
     };
 
     std::unordered_map<uint16_t, LocoCache> m_locoCache;
-    bool isUpdatingDecoderFromKernel = false;
+    bool m_isUpdatingDecoderFromKernel = false;
 
     InputController* m_inputController = nullptr;
     std::array<TriState, rbusAddressMax - rbusAddressMin + 1> m_rbusFeedbackStatus;

--- a/server/src/hardware/protocol/z21/clientkernel.hpp
+++ b/server/src/hardware/protocol/z21/clientkernel.hpp
@@ -122,6 +122,7 @@ class ClientKernel final : public Kernel
       uint8_t speedSteps = 0;
       uint8_t lastReceivedSpeedStep = 0; //Always in 126 steps
       Trend speedTrend = Trend::Ascending;
+      bool speedTrendExplicitlySet = false;
       Direction direction = Direction::Unknown;
       std::chrono::steady_clock::time_point lastSetTime;
     };

--- a/server/src/hardware/protocol/z21/config.hpp
+++ b/server/src/hardware/protocol/z21/config.hpp
@@ -35,6 +35,7 @@ struct Config
 struct ClientConfig : Config
 {
   static constexpr uint16_t keepAliveInterval = 15; //!< sec
+  static constexpr uint16_t purgeInactiveDecoderInternal = 5 * 60; //!< sec
 };
 
 struct ServerConfig : Config

--- a/server/src/hardware/protocol/z21/messages.cpp
+++ b/server/src/hardware/protocol/z21/messages.cpp
@@ -195,7 +195,8 @@ std::string toString(const Message& message, bool raw)
             s.append("estop");
           else
             s.append(std::to_string(locoInfo.speedStep())).append("/").append(std::to_string(locoInfo.speedSteps()));
-          for(uint8_t i = 0; i <= LanXLocoInfo::functionIndexMax; i++)
+          const uint8_t functionIndexMax = locoInfo.functionIndexMax();
+          for(uint8_t i = 0; i <= functionIndexMax; i++)
             s.append(" f").append(std::to_string(i)).append("=").append(locoInfo.getFunction(i) ? "1" : "0");
           s.append(" busy=").append(locoInfo.isBusy() ? "1" : "0");
           break;

--- a/server/src/hardware/protocol/z21/messages.hpp
+++ b/server/src/hardware/protocol/z21/messages.hpp
@@ -1123,6 +1123,9 @@ struct LanXLocoInfo : LanX
   static constexpr uint8_t flagF0 = 0x10;
   static constexpr uint8_t functionIndexMax = 28;
 
+  static constexpr uint8_t minMessageSize = 7 + 7;
+  static constexpr uint8_t maxMessageSize = 7 + 14;
+
   uint8_t addressHigh = 0; //db0
   uint8_t addressLow = 0;  //db1
   uint8_t db2 = 0;
@@ -1131,6 +1134,7 @@ struct LanXLocoInfo : LanX
   uint8_t f5f12 = 0;    //db5
   uint8_t f13f20 = 0;   //db6
   uint8_t f21f28 = 0;   //db7
+  uint8_t f29f31 = 0;   //db8 (firmware >= 1.42)
   uint8_t checksum = 0;
 
   LanXLocoInfo() :
@@ -1223,6 +1227,12 @@ struct LanXLocoInfo : LanX
     Z21::Utils::setSpeedStep(speedAndDirection, speedSteps(), value);
   }
 
+  inline bool supportsF29F31() const
+  {
+    //Firmware >= 1.42 adds db8 to store F29-F31 so dataLen increases to 15
+    return dataLen() >= 15;
+  }
+
   bool getFunction(uint8_t index) const
   {
     if(index == 0)
@@ -1235,6 +1245,8 @@ struct LanXLocoInfo : LanX
       return f13f20 & (1 << (index - 13));
     else if(index <= 28)
       return f21f28 & (1 << (index - 21));
+    else if(index <= 31 && supportsF29F31())
+      return f29f31 & (1 << (index - 29));
     else
       return false;
   }
@@ -1280,6 +1292,14 @@ struct LanXLocoInfo : LanX
       else
         f21f28 &= ~flag;
     }
+    else if(index <= 31 && supportsF29F31())
+    {
+      const uint8_t flag = (1 << (index - 29));
+      if(value)
+        f29f31 |= flag;
+      else
+        f29f31 &= ~flag;
+    }
   }
 
   inline void updateChecksum()
@@ -1288,7 +1308,8 @@ struct LanXLocoInfo : LanX
     LanX::updateChecksum(dataLen() - 6);
   }
 } ATTRIBUTE_PACKED;
-static_assert(sizeof(LanXLocoInfo) == 14);
+static_assert(sizeof(LanXLocoInfo) >= LanXLocoInfo::minMessageSize &&
+              sizeof(LanXLocoInfo) <= LanXLocoInfo::maxMessageSize);
 
 // Reply to LAN_X_GET_FIRMWARE_VERSION
 


### PR DESCRIPTION
Replaces #59

This PR handles receiving loco state from Z21 and update relevant Decoders.

Needs #81 first

- Added support for receiving F29 - F31 (When Z21 firmware version is >= 1.42)
- Fix infinite loop explained in issue #57 (only mitigated)