### PR TITLE
Recognize output state

### DIFF
--- a/server/src/board/tile/rail/decouplerrailtile.cpp
+++ b/server/src/board/tile/rail/decouplerrailtile.cpp
@@ -67,6 +67,11 @@ DecouplerRailTile::DecouplerRailTile(World& world, std::string_view _id)
 
   Attributes::addObjectEditor(deactivate, false);
   m_interfaceItems.add(deactivate);
+
+  outputMap->onOutputStateMatchFound.connect([this](DecouplerState value)
+    {
+      setState(value, true);
+    });
 }
 
 void DecouplerRailTile::worldEvent(WorldState worldState, WorldEvent worldEvent)
@@ -78,11 +83,12 @@ void DecouplerRailTile::worldEvent(WorldState worldState, WorldEvent worldEvent)
   Attributes::setEnabled(name, editable);
 }
 
-void DecouplerRailTile::setState(DecouplerState value)
+void DecouplerRailTile::setState(DecouplerState value, bool skipAction)
 {
   if(state != value)
   {
-    (*outputMap)[value]->execute();
+    if(!skipAction)
+      (*outputMap)[value]->execute();
     state.setValueInternal(value);
   }
 }

--- a/server/src/board/tile/rail/decouplerrailtile.hpp
+++ b/server/src/board/tile/rail/decouplerrailtile.hpp
@@ -37,7 +37,7 @@ class DecouplerRailTile final : public StraightRailTile
   private:
     Node m_node;
 
-    void setState(DecouplerState value);
+    void setState(DecouplerState value, bool skipAction = false);
 
   protected:
     void worldEvent(WorldState worldState, WorldEvent worldEvent) final;

--- a/server/src/board/tile/rail/signal/signal2aspectrailtile.cpp
+++ b/server/src/board/tile/rail/signal/signal2aspectrailtile.cpp
@@ -80,6 +80,8 @@ Signal2AspectRailTile::Signal2AspectRailTile(World& world, std::string_view _id)
 
   Attributes::addValues(setAspect, setAspectValues);
   m_interfaceItems.add(setAspect);
+
+  connectOutputMap();
 }
 
 void Signal2AspectRailTile::boardModified()

--- a/server/src/board/tile/rail/signal/signal3aspectrailtile.cpp
+++ b/server/src/board/tile/rail/signal/signal3aspectrailtile.cpp
@@ -123,6 +123,8 @@ Signal3AspectRailTile::Signal3AspectRailTile(World& world, std::string_view _id)
 
   Attributes::addValues(setAspect, setAspectValues);
   m_interfaceItems.add(setAspect);
+
+  connectOutputMap();
 }
 
 void Signal3AspectRailTile::boardModified()

--- a/server/src/board/tile/rail/signal/signalrailtile.cpp
+++ b/server/src/board/tile/rail/signal/signalrailtile.cpp
@@ -185,3 +185,13 @@ void SignalRailTile::evaluate()
     setAspect(SignalAspect::Stop);
   }
 }
+
+void SignalRailTile::connectOutputMap()
+{
+    outputMap->onOutputStateMatchFound.connect([this](SignalAspect value)
+      {
+        doSetAspect(value);
+      });
+
+    //TODO: disconnect somewhere?
+}

--- a/server/src/board/tile/rail/signal/signalrailtile.cpp
+++ b/server/src/board/tile/rail/signal/signalrailtile.cpp
@@ -191,7 +191,15 @@ void SignalRailTile::connectOutputMap()
 {
     outputMap->onOutputStateMatchFound.connect([this](SignalAspect value)
       {
-        doSetAspect(value, true);
+        bool changed = (value == aspect);
+        if(doSetAspect(value, true))
+        {
+          // If we are in a signal path, re-evaluate our aspect
+          // This corrects accidental modifications of aspect done
+          // by the user with an handset or command station.
+          if(changed && m_signalPath)
+            evaluate();
+        }
       });
 
     //TODO: disconnect somewhere?

--- a/server/src/board/tile/rail/signal/signalrailtile.cpp
+++ b/server/src/board/tile/rail/signal/signalrailtile.cpp
@@ -158,7 +158,7 @@ void SignalRailTile::boardModified()
   StraightRailTile::boardModified();
 }
 
-bool SignalRailTile::doSetAspect(SignalAspect value)
+bool SignalRailTile::doSetAspect(SignalAspect value, bool skipAction)
 {
   const auto* values = setAspect.tryGetValuesAttribute(AttributeName::Values);
   assert(values);
@@ -166,7 +166,8 @@ bool SignalRailTile::doSetAspect(SignalAspect value)
     return false;
   if(aspect != value)
   {
-    (*outputMap)[value]->execute();
+    if(!skipAction)
+      (*outputMap)[value]->execute();
     aspect.setValueInternal(value);
     aspectChanged(*this, value);
     fireEvent(onAspectChanged, shared_ptr<SignalRailTile>(), value);
@@ -190,7 +191,7 @@ void SignalRailTile::connectOutputMap()
 {
     outputMap->onOutputStateMatchFound.connect([this](SignalAspect value)
       {
-        doSetAspect(value);
+        doSetAspect(value, true);
       });
 
     //TODO: disconnect somewhere?

--- a/server/src/board/tile/rail/signal/signalrailtile.hpp
+++ b/server/src/board/tile/rail/signal/signalrailtile.hpp
@@ -54,6 +54,8 @@ class SignalRailTile : public StraightRailTile
 
     void evaluate();
 
+    void connectOutputMap();
+
   public:
     static std::optional<OutputActionValue> getDefaultActionValue(SignalAspect signalAspect, OutputType outputType, size_t outputIndex);
 

--- a/server/src/board/tile/rail/signal/signalrailtile.hpp
+++ b/server/src/board/tile/rail/signal/signalrailtile.hpp
@@ -50,7 +50,7 @@ class SignalRailTile : public StraightRailTile
 
     void boardModified() override;
 
-    virtual bool doSetAspect(SignalAspect value);
+    virtual bool doSetAspect(SignalAspect value, bool skipAction = false);
 
     void evaluate();
 

--- a/server/src/board/tile/rail/turnout/turnout3wayrailtile.cpp
+++ b/server/src/board/tile/rail/turnout/turnout3wayrailtile.cpp
@@ -49,6 +49,8 @@ Turnout3WayRailTile::Turnout3WayRailTile(World& world, std::string_view _id)
 
   Attributes::addValues(setPosition, setPositionValues);
   m_interfaceItems.add(setPosition);
+
+  connectOutputMap();
 }
 
 void Turnout3WayRailTile::getConnectors(std::vector<Connector>& connectors) const

--- a/server/src/board/tile/rail/turnout/turnoutdoublesliprailtile.cpp
+++ b/server/src/board/tile/rail/turnout/turnoutdoublesliprailtile.cpp
@@ -57,6 +57,8 @@ TurnoutDoubleSlipRailTile::TurnoutDoubleSlipRailTile(World& world, std::string_v
 
   Attributes::addValues(setPosition, setPositionValues);
   m_interfaceItems.add(setPosition);
+
+  connectOutputMap();
 }
 
 void TurnoutDoubleSlipRailTile::getConnectors(std::vector<Connector>& connectors) const

--- a/server/src/board/tile/rail/turnout/turnoutleftrailtile.cpp
+++ b/server/src/board/tile/rail/turnout/turnoutleftrailtile.cpp
@@ -76,4 +76,6 @@ TurnoutLeftRailTile::TurnoutLeftRailTile(World& world, std::string_view _id, Til
 
   Attributes::addValues(setPosition, setPositionValues);
   m_interfaceItems.add(setPosition);
+
+  connectOutputMap();
 }

--- a/server/src/board/tile/rail/turnout/turnoutrailtile.cpp
+++ b/server/src/board/tile/rail/turnout/turnoutrailtile.cpp
@@ -99,14 +99,25 @@ bool TurnoutRailTile::isValidPosition(TurnoutPosition value)
   return values->contains(static_cast<int64_t>(value));
 }
 
-bool TurnoutRailTile::doSetPosition(TurnoutPosition value)
+bool TurnoutRailTile::doSetPosition(TurnoutPosition value, bool skipAction)
 {
   if(!isValidPosition(value))
   {
     return false;
   }
-  (*outputMap)[value]->execute();
+  if(!skipAction)
+    (*outputMap)[value]->execute();
   position.setValueInternal(value);
   positionChanged(*this, value);
   return true;
+}
+
+void TurnoutRailTile::connectOutputMap()
+{
+  outputMap->onOutputStateMatchFound.connect([this](TurnoutPosition pos)
+    {
+      doSetPosition(pos, true);
+    });
+
+  //TODO: disconnect somewhere?
 }

--- a/server/src/board/tile/rail/turnout/turnoutrailtile.hpp
+++ b/server/src/board/tile/rail/turnout/turnoutrailtile.hpp
@@ -43,7 +43,9 @@ class TurnoutRailTile : public RailTile
     void worldEvent(WorldState state, WorldEvent event) override;
 
     bool isValidPosition(TurnoutPosition value);
-    virtual bool doSetPosition(TurnoutPosition value);
+    virtual bool doSetPosition(TurnoutPosition value, bool skipAction = false);
+
+    void connectOutputMap();
 
   public:
     boost::signals2::signal<void (const TurnoutRailTile&, TurnoutPosition)> positionChanged;

--- a/server/src/board/tile/rail/turnout/turnoutrightrailtile.cpp
+++ b/server/src/board/tile/rail/turnout/turnoutrightrailtile.cpp
@@ -76,4 +76,6 @@ TurnoutRightRailTile::TurnoutRightRailTile(World& world, std::string_view _id, T
 
   Attributes::addValues(setPosition, setPositionValues);
   m_interfaceItems.add(setPosition);
+
+  connectOutputMap();
 }

--- a/server/src/board/tile/rail/turnout/turnoutsinglesliprailtile.cpp
+++ b/server/src/board/tile/rail/turnout/turnoutsinglesliprailtile.cpp
@@ -55,6 +55,8 @@ TurnoutSingleSlipRailTile::TurnoutSingleSlipRailTile(World& world, std::string_v
 
   Attributes::addValues(setPosition, setPositionValues);
   m_interfaceItems.add(setPosition);
+
+  connectOutputMap();
 }
 
 void TurnoutSingleSlipRailTile::getConnectors(std::vector<Connector>& connectors) const

--- a/server/src/board/tile/rail/turnout/turnoutsinglesliprailtile.cpp
+++ b/server/src/board/tile/rail/turnout/turnoutsinglesliprailtile.cpp
@@ -27,7 +27,7 @@
 
 static const std::array<TurnoutPosition, 5> positionValues = {TurnoutPosition::Unknown,
                                                               TurnoutPosition::Crossed, TurnoutPosition::Diverged,
-                                                              TurnoutPosition::DoubleSlipStraightA, TurnoutPosition::DoubleSlipStraightB,};
+                                                              TurnoutPosition::DoubleSlipStraightA, TurnoutPosition::DoubleSlipStraightB};
 
 static std::optional<OutputActionValue> getDefaultActionValue(TurnoutPosition turnoutPosition, OutputType outputType, size_t outputIndex)
 {

--- a/server/src/board/tile/rail/turnout/turnoutwyerailtile.cpp
+++ b/server/src/board/tile/rail/turnout/turnoutwyerailtile.cpp
@@ -49,6 +49,8 @@ TurnoutWyeRailTile::TurnoutWyeRailTile(World& world, std::string_view _id)
 
   Attributes::addValues(setPosition, setPositionValues);
   m_interfaceItems.add(setPosition);
+
+  connectOutputMap();
 }
 
 void TurnoutWyeRailTile::getConnectors(std::vector<Connector>& connectors) const

--- a/server/src/core/method.hpp
+++ b/server/src/core/method.hpp
@@ -26,19 +26,9 @@
 #include "abstractmethod.hpp"
 #include <functional>
 #include <tuple>
-#include <limits>
-#include <utility>
-#include <traintastic/utils/valuetypetraits.hpp>
-#include "../utils/is_shared_ptr.hpp"
 
 template<class T>
 class Method;
-
-template<std::size_t N, class... A>
-using getArgumentType = typename std::tuple_element<N, std::tuple<A...>>::type;
-
-template<class T>
-inline AbstractMethod::Result toResult(const T& value);
 
 template<class R, class... A>
 class Method<R(A...)> : public AbstractMethod

--- a/server/src/core/method.tpp
+++ b/server/src/core/method.tpp
@@ -24,6 +24,10 @@
 #define TRAINTASTIC_SERVER_CORE_METHOD_TPP
 
 #include "method.hpp"
+#include <limits>
+#include <utility>
+#include <traintastic/utils/valuetypetraits.hpp>
+#include "../utils/is_shared_ptr.hpp"
 
 template<std::size_t N, class... A>
 using getArgumentType = typename std::tuple_element<N, std::tuple<A...>>::type;

--- a/server/src/hardware/output/aspectoutput.cpp
+++ b/server/src/hardware/output/aspectoutput.cpp
@@ -54,4 +54,5 @@ void AspectOutput::updateValue(int16_t newValue)
 {
   value.setValueInternal(newValue);
   fireEvent(onValueChanged, newValue, shared_ptr<AspectOutput>());
+  fireEvent(onValueChangedGeneric, shared_ptr<Output>());
 }

--- a/server/src/hardware/output/ecosstateoutput.cpp
+++ b/server/src/hardware/output/ecosstateoutput.cpp
@@ -53,4 +53,5 @@ void ECoSStateOutput::updateValue(uint8_t newValue)
 {
   value.setValueInternal(newValue);
   fireEvent(onValueChanged, newValue, shared_ptr<ECoSStateOutput>());
+  fireEvent(onValueChangedGeneric, shared_ptr<Output>());
 }

--- a/server/src/hardware/output/map/decoupleroutputmapitem.cpp
+++ b/server/src/hardware/output/map/decoupleroutputmapitem.cpp
@@ -21,7 +21,7 @@
  */
 
 #include "decoupleroutputmapitem.hpp"
-#include "../../../core/method.tpp"
+#include "outputmapitembase.tpp"
 
 DecouplerOutputMapItem::DecouplerOutputMapItem(Object& map, DecouplerState state) :
   OutputMapItemBase(map, state)

--- a/server/src/hardware/output/map/outputmap.cpp
+++ b/server/src/hardware/output/map/outputmap.cpp
@@ -39,12 +39,6 @@
 #include "../../../utils/displayname.hpp"
 #include "../../../utils/inrange.hpp"
 
-//TODO: needed for connecting value changed signal. Can be avoided?
-#include "../singleoutput.hpp"
-#include "../pairoutput.hpp"
-#include "../aspectoutput.hpp"
-#include "../ecosstateoutput.hpp"
-
 OutputMap::OutputMap(Object& _parent, std::string_view parentPropertyName)
   : SubObject(_parent, parentPropertyName)
   , interface{this, "interface", nullptr, PropertyFlags::ReadWrite | PropertyFlags::Store | PropertyFlags::NoScript,

--- a/server/src/hardware/output/map/outputmap.cpp
+++ b/server/src/hardware/output/map/outputmap.cpp
@@ -587,16 +587,29 @@ std::shared_ptr<OutputMapOutputAction> OutputMap::createOutputAction(OutputType 
 int OutputMap::getMatchingActionOnCurrentState()
 {
   int i = 0;
+  int wildcardIdx = -1;
+
   for(const auto& item : items)
   {
-    TriState value = item->matchesCurrentOutputState();
-    if(value == TriState::True)
+    OutputMapItem::MatchResult value = item->matchesCurrentOutputState();
+    if(value == OutputMapItem::MatchResult::FullMatch)
     {
-      return i;
+      return i; // We got a full match
+    }
+    else if(value == OutputMapItem::MatchResult::WildcardMatch)
+    {
+      // We give wildcard matches a lower priority.
+      // Save it for later, in the meantime we check for a better full match
+      if(wildcardIdx == -1)
+        wildcardIdx = i;
     }
 
     i++;
   }
+
+  // No full match, do we have a wildcard match?
+  if(wildcardIdx != -1)
+    return wildcardIdx;
 
   return -1; // No match found
 }

--- a/server/src/hardware/output/map/outputmap.cpp
+++ b/server/src/hardware/output/map/outputmap.cpp
@@ -626,26 +626,10 @@ void OutputMap::addOutput(OutputChannel ch, uint32_t id, OutputController& outpu
 OutputMap::OutputConnectionPair OutputMap::getOutput(OutputChannel ch, uint32_t id, OutputController& outputController)
 {
   auto output = outputController.getOutput(ch, id, parent());
+  if(!output)
+    return {};
 
-  boost::signals2::connection conn;
-
-  if(auto *single = dynamic_cast<SingleOutput*>(output.get()))
-  {
-    conn = single->onValueChanged.connect([this](bool, const std::shared_ptr<SingleOutput>&){ updateStateFromOutput(); });
-  }
-  else if(auto* pair = dynamic_cast<PairOutput*>(output.get()))
-  {
-    conn = pair->onValueChanged.connect([this](OutputPairValue, const std::shared_ptr<PairOutput>&){ updateStateFromOutput(); });
-  }
-  else if(auto* aspect = dynamic_cast<AspectOutput*>(output.get()))
-  {
-    conn = aspect->onValueChanged.connect([this](int16_t, const std::shared_ptr<AspectOutput>&){ updateStateFromOutput(); });
-  }
-  else if(auto* ecosState = dynamic_cast<ECoSStateOutput*>(output.get()))
-  {
-    conn = ecosState->onValueChanged.connect([this](uint8_t, const std::shared_ptr<ECoSStateOutput>&){ updateStateFromOutput(); });
-  }
-
+  boost::signals2::connection conn = output->onValueChangedGeneric.connect([this](const std::shared_ptr<Output>&){ updateStateFromOutput(); });
   return {output, conn};
 }
 

--- a/server/src/hardware/output/map/outputmap.hpp
+++ b/server/src/hardware/output/map/outputmap.hpp
@@ -43,7 +43,8 @@ class OutputMap : public SubObject
 {
   public:
     using Items = std::vector<std::shared_ptr<OutputMapItem>>;
-    using Outputs = std::vector<std::shared_ptr<Output>>;
+    using OutputConnectionPair = std::pair<std::shared_ptr<Output>, boost::signals2::connection>;
+    using Outputs = std::vector<OutputConnectionPair>;
 
   private:
     static constexpr size_t addressesSizeMin = 1;
@@ -54,8 +55,8 @@ class OutputMap : public SubObject
 
     void addOutput(OutputChannel ch, uint32_t id);
     void addOutput(OutputChannel ch, uint32_t id, OutputController& outputController);
-    std::shared_ptr<Output> getOutput(OutputChannel ch, uint32_t id, OutputController& outputController);
-    void releaseOutput(Output& output);
+    OutputConnectionPair getOutput(OutputChannel ch, uint32_t id, OutputController& outputController);
+    void releaseOutput(OutputConnectionPair& outputConnPair);
 
   protected:
     Outputs m_outputs;
@@ -76,6 +77,10 @@ class OutputMap : public SubObject
 
     virtual std::optional<OutputActionValue> getDefaultOutputActionValue(const OutputMapItem& item, OutputType outputType, size_t outputIndex) = 0;
 
+    int getMatchingActionOnCurrentState();
+
+    virtual void updateStateFromOutput();
+
   public:
     ObjectProperty<OutputController> interface;
     Property<OutputChannel> channel;
@@ -91,7 +96,7 @@ class OutputMap : public SubObject
     const std::shared_ptr<Output>& output(size_t index) const
     {
       assert(index < m_outputs.size());
-      return m_outputs[index];
+      return m_outputs[index].first;
     }
 };
 

--- a/server/src/hardware/output/map/outputmapaspectoutputaction.cpp
+++ b/server/src/hardware/output/map/outputmapaspectoutputaction.cpp
@@ -41,6 +41,11 @@ void OutputMapAspectOutputAction::execute()
   aspectOutput().setValue(aspect);
 }
 
+bool OutputMapAspectOutputAction::matchesCurrentOutputState()
+{
+  return aspectOutput().value.value() == aspect;
+}
+
 void OutputMapAspectOutputAction::worldEvent(WorldState state, WorldEvent event)
 {
   OutputMapOutputAction::worldEvent(state, event);

--- a/server/src/hardware/output/map/outputmapaspectoutputaction.cpp
+++ b/server/src/hardware/output/map/outputmapaspectoutputaction.cpp
@@ -60,3 +60,9 @@ AspectOutput& OutputMapAspectOutputAction::aspectOutput()
   assert(dynamic_cast<AspectOutput*>(&output()));
   return static_cast<AspectOutput&>(output());
 }
+
+const AspectOutput& OutputMapAspectOutputAction::aspectOutput() const
+{
+    assert(dynamic_cast<const AspectOutput*>(&output()));
+    return static_cast<const AspectOutput&>(output());
+}

--- a/server/src/hardware/output/map/outputmapaspectoutputaction.cpp
+++ b/server/src/hardware/output/map/outputmapaspectoutputaction.cpp
@@ -41,7 +41,7 @@ void OutputMapAspectOutputAction::execute()
   aspectOutput().setValue(aspect);
 }
 
-bool OutputMapAspectOutputAction::matchesCurrentOutputState()
+bool OutputMapAspectOutputAction::matchesCurrentOutputState() const
 {
   return aspectOutput().value.value() == aspect;
 }

--- a/server/src/hardware/output/map/outputmapaspectoutputaction.cpp
+++ b/server/src/hardware/output/map/outputmapaspectoutputaction.cpp
@@ -41,9 +41,9 @@ void OutputMapAspectOutputAction::execute()
   aspectOutput().setValue(aspect);
 }
 
-bool OutputMapAspectOutputAction::matchesCurrentOutputState() const
+TriState OutputMapAspectOutputAction::matchesCurrentOutputState() const
 {
-  return aspectOutput().value.value() == aspect;
+  return toTriState(aspectOutput().value.value() == aspect);
 }
 
 void OutputMapAspectOutputAction::worldEvent(WorldState state, WorldEvent event)

--- a/server/src/hardware/output/map/outputmapaspectoutputaction.hpp
+++ b/server/src/hardware/output/map/outputmapaspectoutputaction.hpp
@@ -33,6 +33,7 @@ class OutputMapAspectOutputAction final : public OutputMapOutputAction
 
   private:
     AspectOutput& aspectOutput();
+    const AspectOutput& aspectOutput() const;
 
   protected:
     void worldEvent(WorldState state, WorldEvent event) final;

--- a/server/src/hardware/output/map/outputmapaspectoutputaction.hpp
+++ b/server/src/hardware/output/map/outputmapaspectoutputaction.hpp
@@ -44,7 +44,7 @@ class OutputMapAspectOutputAction final : public OutputMapOutputAction
 
     void execute() final;
 
-    bool matchesCurrentOutputState() final;
+    bool matchesCurrentOutputState() const final;
 };
 
 #endif

--- a/server/src/hardware/output/map/outputmapaspectoutputaction.hpp
+++ b/server/src/hardware/output/map/outputmapaspectoutputaction.hpp
@@ -43,6 +43,8 @@ class OutputMapAspectOutputAction final : public OutputMapOutputAction
     OutputMapAspectOutputAction(OutputMap& _parent, size_t outputIndex);
 
     void execute() final;
+
+    bool matchesCurrentOutputState() final;
 };
 
 #endif

--- a/server/src/hardware/output/map/outputmapaspectoutputaction.hpp
+++ b/server/src/hardware/output/map/outputmapaspectoutputaction.hpp
@@ -45,7 +45,7 @@ class OutputMapAspectOutputAction final : public OutputMapOutputAction
 
     void execute() final;
 
-    bool matchesCurrentOutputState() const final;
+    TriState matchesCurrentOutputState() const final;
 };
 
 #endif

--- a/server/src/hardware/output/map/outputmapbase.hpp
+++ b/server/src/hardware/output/map/outputmapbase.hpp
@@ -25,7 +25,6 @@
 
 #include "outputmap.hpp"
 #include <initializer_list>
-#include "outputmapoutputaction.hpp"
 #include "../../../core/event.hpp"
 
 template<class Key, class Value>

--- a/server/src/hardware/output/map/outputmapecosstateoutputaction.cpp
+++ b/server/src/hardware/output/map/outputmapecosstateoutputaction.cpp
@@ -41,6 +41,11 @@ void OutputMapECoSStateOutputAction::execute()
   ecosStateOutput().setValue(state);
 }
 
+bool OutputMapECoSStateOutputAction::matchesCurrentOutputState()
+{
+  return ecosStateOutput().value.value() == state;
+}
+
 void OutputMapECoSStateOutputAction::worldEvent(WorldState worldState, WorldEvent event)
 {
   OutputMapOutputAction::worldEvent(worldState, event);

--- a/server/src/hardware/output/map/outputmapecosstateoutputaction.cpp
+++ b/server/src/hardware/output/map/outputmapecosstateoutputaction.cpp
@@ -41,7 +41,7 @@ void OutputMapECoSStateOutputAction::execute()
   ecosStateOutput().setValue(state);
 }
 
-bool OutputMapECoSStateOutputAction::matchesCurrentOutputState()
+bool OutputMapECoSStateOutputAction::matchesCurrentOutputState() const
 {
   return ecosStateOutput().value.value() == state;
 }

--- a/server/src/hardware/output/map/outputmapecosstateoutputaction.cpp
+++ b/server/src/hardware/output/map/outputmapecosstateoutputaction.cpp
@@ -60,3 +60,9 @@ ECoSStateOutput& OutputMapECoSStateOutputAction::ecosStateOutput()
   assert(dynamic_cast<ECoSStateOutput*>(&output()));
   return static_cast<ECoSStateOutput&>(output());
 }
+
+const ECoSStateOutput& OutputMapECoSStateOutputAction::ecosStateOutput() const
+{
+    assert(dynamic_cast<const ECoSStateOutput*>(&output()));
+    return static_cast<const ECoSStateOutput&>(output());
+}

--- a/server/src/hardware/output/map/outputmapecosstateoutputaction.cpp
+++ b/server/src/hardware/output/map/outputmapecosstateoutputaction.cpp
@@ -41,9 +41,9 @@ void OutputMapECoSStateOutputAction::execute()
   ecosStateOutput().setValue(state);
 }
 
-bool OutputMapECoSStateOutputAction::matchesCurrentOutputState() const
+TriState OutputMapECoSStateOutputAction::matchesCurrentOutputState() const
 {
-  return ecosStateOutput().value.value() == state;
+  return toTriState(ecosStateOutput().value.value() == state);
 }
 
 void OutputMapECoSStateOutputAction::worldEvent(WorldState worldState, WorldEvent event)

--- a/server/src/hardware/output/map/outputmapecosstateoutputaction.hpp
+++ b/server/src/hardware/output/map/outputmapecosstateoutputaction.hpp
@@ -45,7 +45,7 @@ class OutputMapECoSStateOutputAction final : public OutputMapOutputAction
 
     void execute() final;
 
-    bool matchesCurrentOutputState() const final;
+    TriState matchesCurrentOutputState() const final;
 };
 
 #endif

--- a/server/src/hardware/output/map/outputmapecosstateoutputaction.hpp
+++ b/server/src/hardware/output/map/outputmapecosstateoutputaction.hpp
@@ -43,6 +43,8 @@ class OutputMapECoSStateOutputAction final : public OutputMapOutputAction
     OutputMapECoSStateOutputAction(OutputMap& _parent, size_t outputIndex);
 
     void execute() final;
+
+    bool matchesCurrentOutputState() final;
 };
 
 #endif

--- a/server/src/hardware/output/map/outputmapecosstateoutputaction.hpp
+++ b/server/src/hardware/output/map/outputmapecosstateoutputaction.hpp
@@ -33,6 +33,7 @@ class OutputMapECoSStateOutputAction final : public OutputMapOutputAction
 
   private:
     ECoSStateOutput& ecosStateOutput();
+    const ECoSStateOutput& ecosStateOutput() const;
 
   protected:
     void worldEvent(WorldState worldState, WorldEvent event) final;

--- a/server/src/hardware/output/map/outputmapecosstateoutputaction.hpp
+++ b/server/src/hardware/output/map/outputmapecosstateoutputaction.hpp
@@ -44,7 +44,7 @@ class OutputMapECoSStateOutputAction final : public OutputMapOutputAction
 
     void execute() final;
 
-    bool matchesCurrentOutputState() final;
+    bool matchesCurrentOutputState() const final;
 };
 
 #endif

--- a/server/src/hardware/output/map/outputmapitem.cpp
+++ b/server/src/hardware/output/map/outputmapitem.cpp
@@ -41,32 +41,39 @@ void OutputMapItem::execute()
   }
 }
 
-TriState OutputMapItem::matchesCurrentOutputState() const
+OutputMapItem::MatchResult OutputMapItem::matchesCurrentOutputState() const
 {
   bool atLeastOneMatch = false;
   bool atLeastOneDifference = false;
+  bool atLeastOneWildcard = false;
 
   for(const auto& action : outputActions)
   {
-    bool match = action->matchesCurrentOutputState();
-    if(match)
+    TriState match = action->matchesCurrentOutputState();
+    switch (match)
     {
-      atLeastOneMatch = true;
-    }
-    else
-    {
+    case TriState::Undefined:
+      atLeastOneWildcard = true;
+      break;
+    case TriState::False:
       atLeastOneDifference = true;
+      break;
+    case TriState::True:
+      atLeastOneMatch = true;
+      break;
     }
 
     // This state could be the coorect one but output feedback is not yet arrived
     // We will re-check when we receive output feedback from command station
-    if(atLeastOneMatch && atLeastOneDifference)
-      return TriState::Undefined;
+    if(atLeastOneDifference && (atLeastOneMatch || atLeastOneWildcard))
+      return MatchResult::PartialMatch;
   }
 
+  if(atLeastOneWildcard)
+    return MatchResult::WildcardMatch;
   if(atLeastOneMatch)
-    return TriState::True;
-  return TriState::False;
+    return MatchResult::FullMatch;
+  return MatchResult::NoMatch;
 }
 
 void OutputMapItem::worldEvent(WorldState state, WorldEvent event)

--- a/server/src/hardware/output/map/outputmapitem.cpp
+++ b/server/src/hardware/output/map/outputmapitem.cpp
@@ -41,6 +41,34 @@ void OutputMapItem::execute()
   }
 }
 
+TriState OutputMapItem::matchesCurrentOutputState() const
+{
+  bool atLeastOneMatch = false;
+  bool atLeastOneDifference = false;
+
+  for(const auto& action : outputActions)
+  {
+    bool match = action->matchesCurrentOutputState();
+    if(match)
+    {
+      atLeastOneMatch = true;
+    }
+    else
+    {
+      atLeastOneDifference = true;
+    }
+
+    // This state could be the coorect one but output feedback is not yet arrived
+    // We will re-check when we receive output feedback from command station
+    if(atLeastOneMatch && atLeastOneDifference)
+      return TriState::Undefined;
+  }
+
+  if(atLeastOneMatch)
+    return TriState::True;
+  return TriState::False;
+}
+
 void OutputMapItem::worldEvent(WorldState state, WorldEvent event)
 {
   Object::worldEvent(state, event);

--- a/server/src/hardware/output/map/outputmapitem.hpp
+++ b/server/src/hardware/output/map/outputmapitem.hpp
@@ -41,13 +41,21 @@ class OutputMapItem : public Object
     void worldEvent(WorldState state, WorldEvent event) override;
 
   public:
+    enum class MatchResult
+    {
+      FullMatch = 0,     // Every action matches
+      PartialMatch = 1,  // Some actions do not match, probably switch operation is not completed yet
+      WildcardMatch = 2, // Some action are set to "None", they match any state but are ranked below others
+      NoMatch = 3        // None of the actions matches
+    };
+
     ObjectVectorProperty<OutputMapOutputAction> outputActions;
 
     OutputMapItem(Object& map);
 
     void execute();
 
-    TriState matchesCurrentOutputState() const;
+    MatchResult matchesCurrentOutputState() const;
 };
 
 #endif

--- a/server/src/hardware/output/map/outputmapitem.hpp
+++ b/server/src/hardware/output/map/outputmapitem.hpp
@@ -25,6 +25,7 @@
 
 #include "../../../core/object.hpp"
 #include "../../../core/objectvectorproperty.hpp"
+#include "traintastic/enum/tristate.hpp"
 
 class Output;
 class OutputMap;
@@ -45,6 +46,8 @@ class OutputMapItem : public Object
     OutputMapItem(Object& map);
 
     void execute();
+
+    TriState matchesCurrentOutputState() const;
 };
 
 #endif

--- a/server/src/hardware/output/map/outputmapitembase.hpp
+++ b/server/src/hardware/output/map/outputmapitembase.hpp
@@ -24,11 +24,10 @@
 #define TRAINTASTIC_SERVER_HARDWARE_OUTPUT_MAP_OUTPUTMAPITEMBASE_HPP
 
 #include "outputmapitem.hpp"
-#include <vector>
-#include "../../../core/attributes.hpp"
 #include "../../../core/method.hpp"
-#include "../output.hpp"
-#include "outputmapoutputaction.hpp"
+#include "../../../core/property.hpp"
+
+class OutputMapOutputAction;
 
 template<class Key>
 class OutputMapItemBase : public OutputMapItem
@@ -44,42 +43,9 @@ class OutputMapItemBase : public OutputMapItem
     Property<bool> use;
     Method<std::shared_ptr<OutputMapOutputAction> (uint32_t)> getOutputAction;
 
-    OutputMapItemBase(Object& map, Key _key) :
-      OutputMapItem(map),
-      m_keyValues{{_key}},
-      key{this, "key", _key, PropertyFlags::ReadOnly | PropertyFlags::Store},
-      use{this, "use", true, PropertyFlags::ReadWrite | PropertyFlags::Store},
-      getOutputAction{*this, "get_output_action",
-        [this](uint32_t index)
-        {
-          return index < outputActions.size() ? outputActions[index] : std::shared_ptr<OutputMapOutputAction>();
-        }}
-    {
-      Attributes::addValues(key, m_keyValues);
-      m_interfaceItems.add(key);
-      Attributes::addEnabled(use, false);
-      m_interfaceItems.add(use);
-      m_interfaceItems.add(getOutputAction);
-    }
+    OutputMapItemBase(Object& map, Key _key);
 
-    std::string getObjectId() const final
-    {
-      std::string id{m_map.getObjectId()};
-      id.append(".");
-      if constexpr(std::is_enum_v<Key>)
-      {
-        id.append(EnumValues<Key>::value.find(key)->second);
-      }
-      else if constexpr(std::is_same_v<Key, bool>)
-      {
-        id.append(key ? "true" : "false");
-      }
-      else
-      {
-        static_assert(sizeof(Key) != sizeof(Key));
-      }
-      return id;
-    }
+    std::string getObjectId() const final;
 };
 
 #endif

--- a/server/src/hardware/output/map/outputmapitembase.tpp
+++ b/server/src/hardware/output/map/outputmapitembase.tpp
@@ -1,0 +1,49 @@
+#ifndef TRAINTASTIC_SERVER_HARDWARE_OUTPUT_MAP_OUTPUTMAPITEMBASE_TPP
+#define TRAINTASTIC_SERVER_HARDWARE_OUTPUT_MAP_OUTPUTMAPITEMBASE_TPP
+
+#include "outputmapitembase.hpp"
+
+#include "../../../core/attributes.hpp"
+#include "../../../core/method.tpp"
+#include "outputmapoutputaction.hpp"
+
+template<class Key>
+OutputMapItemBase<Key>::OutputMapItemBase(Object& map, Key _key)
+  : OutputMapItem(map)
+  , m_keyValues{{_key}}
+  , key{this, "key", _key, PropertyFlags::ReadOnly | PropertyFlags::Store}
+  , use{this, "use", true, PropertyFlags::ReadWrite | PropertyFlags::Store}
+  , getOutputAction{*this, "get_output_action",
+      [this](uint32_t index)
+      {
+        return index < outputActions.size() ? outputActions[index] : std::shared_ptr<OutputMapOutputAction>();
+      }}
+{
+  Attributes::addValues(key, m_keyValues);
+  m_interfaceItems.add(key);
+  Attributes::addEnabled(use, false);
+  m_interfaceItems.add(use);
+  m_interfaceItems.add(getOutputAction);
+}
+
+template<class Key>
+std::string OutputMapItemBase<Key>::getObjectId() const
+{
+  std::string id{m_map.getObjectId()};
+  id.append(".");
+  if constexpr(std::is_enum_v<Key>)
+  {
+    id.append(EnumValues<Key>::value.find(key)->second);
+  }
+  else if constexpr(std::is_same_v<Key, bool>)
+  {
+    id.append(key ? "true" : "false");
+  }
+  else
+  {
+    static_assert(sizeof(Key) != sizeof(Key));
+  }
+  return id;
+}
+
+#endif // TRAINTASTIC_SERVER_HARDWARE_OUTPUT_MAP_OUTPUTMAPITEMBASE_TPP

--- a/server/src/hardware/output/map/outputmapoutputaction.cpp
+++ b/server/src/hardware/output/map/outputmapoutputaction.cpp
@@ -48,3 +48,8 @@ Output& OutputMapOutputAction::output()
 {
   return *m_parent.output(m_outputIndex);
 }
+
+const Output& OutputMapOutputAction::output() const
+{
+    return *m_parent.output(m_outputIndex);
+}

--- a/server/src/hardware/output/map/outputmapoutputaction.hpp
+++ b/server/src/hardware/output/map/outputmapoutputaction.hpp
@@ -25,6 +25,7 @@
 
 #include "../../../core/object.hpp"
 #include "../output.hpp"
+#include "traintastic/enum/tristate.hpp"
 
 class OutputMap;
 class World;
@@ -49,7 +50,7 @@ class OutputMapOutputAction : public Object
 
     virtual void execute() = 0;
 
-    virtual bool matchesCurrentOutputState() const = 0;
+    virtual TriState matchesCurrentOutputState() const = 0;
 };
 
 #endif

--- a/server/src/hardware/output/map/outputmapoutputaction.hpp
+++ b/server/src/hardware/output/map/outputmapoutputaction.hpp
@@ -47,6 +47,8 @@ class OutputMapOutputAction : public Object
     std::string getObjectId() const final;
 
     virtual void execute() = 0;
+
+    virtual bool matchesCurrentOutputState() = 0; //TODO: const
 };
 
 #endif

--- a/server/src/hardware/output/map/outputmapoutputaction.hpp
+++ b/server/src/hardware/output/map/outputmapoutputaction.hpp
@@ -48,7 +48,7 @@ class OutputMapOutputAction : public Object
 
     virtual void execute() = 0;
 
-    virtual bool matchesCurrentOutputState() = 0; //TODO: const
+    virtual bool matchesCurrentOutputState() const = 0;
 };
 
 #endif

--- a/server/src/hardware/output/map/outputmapoutputaction.hpp
+++ b/server/src/hardware/output/map/outputmapoutputaction.hpp
@@ -40,6 +40,7 @@ class OutputMapOutputAction : public Object
   protected:
     World& world();
     Output& output();
+    const Output& output() const;
 
   public:
     OutputMapOutputAction(OutputMap& _parent, size_t outputIndex);

--- a/server/src/hardware/output/map/outputmappairoutputaction.cpp
+++ b/server/src/hardware/output/map/outputmappairoutputaction.cpp
@@ -54,29 +54,29 @@ void OutputMapPairOutputAction::execute()
   }
 }
 
-bool OutputMapPairOutputAction::matchesCurrentOutputState() const
+TriState OutputMapPairOutputAction::matchesCurrentOutputState() const
 {
   switch(action.value())
   {
     case PairOutputAction::None:
-      return true; // None means "any state is ok"
+      return TriState::Undefined; // None means "any state is ok"
 
     case PairOutputAction::First:
     {
       if(pairOutput().value.value() == OutputPairValue::First)
-        return true;
+        return TriState::True;
       break;
     }
 
     case PairOutputAction::Second:
     {
       if(pairOutput().value.value() == OutputPairValue::Second)
-        return true;
+        return TriState::True;
       break;
     }
   }
 
-  return false;
+  return TriState::False;
 }
 
 void OutputMapPairOutputAction::worldEvent(WorldState state, WorldEvent event)

--- a/server/src/hardware/output/map/outputmappairoutputaction.cpp
+++ b/server/src/hardware/output/map/outputmappairoutputaction.cpp
@@ -93,3 +93,9 @@ PairOutput& OutputMapPairOutputAction::pairOutput()
   assert(dynamic_cast<PairOutput*>(&output()));
   return static_cast<PairOutput&>(output());
 }
+
+const PairOutput& OutputMapPairOutputAction::pairOutput() const
+{
+    assert(dynamic_cast<const PairOutput*>(&output()));
+    return static_cast<const PairOutput&>(output());
+}

--- a/server/src/hardware/output/map/outputmappairoutputaction.cpp
+++ b/server/src/hardware/output/map/outputmappairoutputaction.cpp
@@ -59,7 +59,7 @@ bool OutputMapPairOutputAction::matchesCurrentOutputState()
   switch(action.value())
   {
     case PairOutputAction::None:
-      break;
+      return true; // None means "any state is ok"
 
     case PairOutputAction::First:
     {

--- a/server/src/hardware/output/map/outputmappairoutputaction.cpp
+++ b/server/src/hardware/output/map/outputmappairoutputaction.cpp
@@ -54,7 +54,7 @@ void OutputMapPairOutputAction::execute()
   }
 }
 
-bool OutputMapPairOutputAction::matchesCurrentOutputState()
+bool OutputMapPairOutputAction::matchesCurrentOutputState() const
 {
   switch(action.value())
   {

--- a/server/src/hardware/output/map/outputmappairoutputaction.cpp
+++ b/server/src/hardware/output/map/outputmappairoutputaction.cpp
@@ -54,6 +54,31 @@ void OutputMapPairOutputAction::execute()
   }
 }
 
+bool OutputMapPairOutputAction::matchesCurrentOutputState()
+{
+  switch(action.value())
+  {
+    case PairOutputAction::None:
+      break;
+
+    case PairOutputAction::First:
+    {
+      if(pairOutput().value.value() == OutputPairValue::First)
+        return true;
+      break;
+    }
+
+    case PairOutputAction::Second:
+    {
+      if(pairOutput().value.value() == OutputPairValue::Second)
+        return true;
+      break;
+    }
+  }
+
+  return false;
+}
+
 void OutputMapPairOutputAction::worldEvent(WorldState state, WorldEvent event)
 {
   OutputMapOutputAction::worldEvent(state, event);

--- a/server/src/hardware/output/map/outputmappairoutputaction.hpp
+++ b/server/src/hardware/output/map/outputmappairoutputaction.hpp
@@ -44,6 +44,8 @@ class OutputMapPairOutputAction final : public OutputMapOutputAction
     OutputMapPairOutputAction(OutputMap& _parent, size_t outputIndex);
 
     void execute() final;
+
+    bool matchesCurrentOutputState() final;
 };
 
 #endif

--- a/server/src/hardware/output/map/outputmappairoutputaction.hpp
+++ b/server/src/hardware/output/map/outputmappairoutputaction.hpp
@@ -46,7 +46,7 @@ class OutputMapPairOutputAction final : public OutputMapOutputAction
 
     void execute() final;
 
-    bool matchesCurrentOutputState() const final;
+    TriState matchesCurrentOutputState() const final;
 };
 
 #endif

--- a/server/src/hardware/output/map/outputmappairoutputaction.hpp
+++ b/server/src/hardware/output/map/outputmappairoutputaction.hpp
@@ -45,7 +45,7 @@ class OutputMapPairOutputAction final : public OutputMapOutputAction
 
     void execute() final;
 
-    bool matchesCurrentOutputState() final;
+    bool matchesCurrentOutputState() const final;
 };
 
 #endif

--- a/server/src/hardware/output/map/outputmappairoutputaction.hpp
+++ b/server/src/hardware/output/map/outputmappairoutputaction.hpp
@@ -34,6 +34,7 @@ class OutputMapPairOutputAction final : public OutputMapOutputAction
 
   private:
     PairOutput& pairOutput();
+    const PairOutput& pairOutput() const;
 
   protected:
     void worldEvent(WorldState state, WorldEvent event) final;

--- a/server/src/hardware/output/map/outputmapsingleoutputaction.cpp
+++ b/server/src/hardware/output/map/outputmapsingleoutputaction.cpp
@@ -71,6 +71,8 @@ bool OutputMapSingleOutputAction::matchesCurrentOutputState()
   switch(action.value())
   {
     case SingleOutputAction::None:
+      return true; // None means "any state is ok"
+
     case SingleOutputAction::Pulse: //TODO: how to detect pulse???
       break;
 

--- a/server/src/hardware/output/map/outputmapsingleoutputaction.cpp
+++ b/server/src/hardware/output/map/outputmapsingleoutputaction.cpp
@@ -108,3 +108,9 @@ SingleOutput& OutputMapSingleOutputAction::singleOutput()
   assert(dynamic_cast<SingleOutput*>(&output()));
   return static_cast<SingleOutput&>(output());
 }
+
+const SingleOutput& OutputMapSingleOutputAction::singleOutput() const
+{
+    assert(dynamic_cast<const SingleOutput*>(&output()));
+    return static_cast<const SingleOutput&>(output());
+}

--- a/server/src/hardware/output/map/outputmapsingleoutputaction.cpp
+++ b/server/src/hardware/output/map/outputmapsingleoutputaction.cpp
@@ -66,6 +66,32 @@ void OutputMapSingleOutputAction::execute()
   }
 }
 
+bool OutputMapSingleOutputAction::matchesCurrentOutputState()
+{
+  switch(action.value())
+  {
+    case SingleOutputAction::None:
+    case SingleOutputAction::Pulse: //TODO: how to detect pulse???
+      break;
+
+    case SingleOutputAction::Off:
+    {
+      if(singleOutput().value.value() == TriState::False)
+        return true;
+      break;
+    }
+
+    case SingleOutputAction::On:
+    {
+      if(singleOutput().value.value() == TriState::True)
+        return true;
+      break;
+    }
+  }
+
+  return false;
+}
+
 void OutputMapSingleOutputAction::worldEvent(WorldState state, WorldEvent event)
 {
   OutputMapOutputAction::worldEvent(state, event);

--- a/server/src/hardware/output/map/outputmapsingleoutputaction.cpp
+++ b/server/src/hardware/output/map/outputmapsingleoutputaction.cpp
@@ -66,12 +66,12 @@ void OutputMapSingleOutputAction::execute()
   }
 }
 
-bool OutputMapSingleOutputAction::matchesCurrentOutputState() const
+TriState OutputMapSingleOutputAction::matchesCurrentOutputState() const
 {
   switch(action.value())
   {
     case SingleOutputAction::None:
-      return true; // None means "any state is ok"
+      return TriState::Undefined; // None means "any state is ok"
 
     case SingleOutputAction::Pulse: //TODO: how to detect pulse???
       break;
@@ -79,19 +79,19 @@ bool OutputMapSingleOutputAction::matchesCurrentOutputState() const
     case SingleOutputAction::Off:
     {
       if(singleOutput().value.value() == TriState::False)
-        return true;
+        return TriState::True;
       break;
     }
 
     case SingleOutputAction::On:
     {
       if(singleOutput().value.value() == TriState::True)
-        return true;
+        return TriState::True;
       break;
     }
   }
 
-  return false;
+  return TriState::False;
 }
 
 void OutputMapSingleOutputAction::worldEvent(WorldState state, WorldEvent event)

--- a/server/src/hardware/output/map/outputmapsingleoutputaction.cpp
+++ b/server/src/hardware/output/map/outputmapsingleoutputaction.cpp
@@ -66,7 +66,7 @@ void OutputMapSingleOutputAction::execute()
   }
 }
 
-bool OutputMapSingleOutputAction::matchesCurrentOutputState()
+bool OutputMapSingleOutputAction::matchesCurrentOutputState() const
 {
   switch(action.value())
   {

--- a/server/src/hardware/output/map/outputmapsingleoutputaction.hpp
+++ b/server/src/hardware/output/map/outputmapsingleoutputaction.hpp
@@ -45,7 +45,7 @@ class OutputMapSingleOutputAction final : public OutputMapOutputAction
 
     void execute() final;
 
-    bool matchesCurrentOutputState() final;
+    bool matchesCurrentOutputState() const final;
 };
 
 #endif

--- a/server/src/hardware/output/map/outputmapsingleoutputaction.hpp
+++ b/server/src/hardware/output/map/outputmapsingleoutputaction.hpp
@@ -46,7 +46,7 @@ class OutputMapSingleOutputAction final : public OutputMapOutputAction
 
     void execute() final;
 
-    bool matchesCurrentOutputState() const final;
+    TriState matchesCurrentOutputState() const final;
 };
 
 #endif

--- a/server/src/hardware/output/map/outputmapsingleoutputaction.hpp
+++ b/server/src/hardware/output/map/outputmapsingleoutputaction.hpp
@@ -34,6 +34,7 @@ class OutputMapSingleOutputAction final : public OutputMapOutputAction
 
   private:
     SingleOutput& singleOutput();
+    const SingleOutput& singleOutput() const;
 
   protected:
     void worldEvent(WorldState state, WorldEvent event) final;

--- a/server/src/hardware/output/map/outputmapsingleoutputaction.hpp
+++ b/server/src/hardware/output/map/outputmapsingleoutputaction.hpp
@@ -44,6 +44,8 @@ class OutputMapSingleOutputAction final : public OutputMapOutputAction
     OutputMapSingleOutputAction(OutputMap& _parent, size_t outputIndex);
 
     void execute() final;
+
+    bool matchesCurrentOutputState() final;
 };
 
 #endif

--- a/server/src/hardware/output/map/signaloutputmapitem.cpp
+++ b/server/src/hardware/output/map/signaloutputmapitem.cpp
@@ -21,7 +21,7 @@
  */
 
 #include "signaloutputmapitem.hpp"
-#include "../../../core/attributes.hpp"
+#include "outputmapitembase.tpp"
 
 SignalOutputMapItem::SignalOutputMapItem(Object& map, SignalAspect aspect) :
   OutputMapItemBase(map, aspect)

--- a/server/src/hardware/output/map/signaloutputmapitem.cpp
+++ b/server/src/hardware/output/map/signaloutputmapitem.cpp
@@ -22,7 +22,6 @@
 
 #include "signaloutputmapitem.hpp"
 #include "../../../core/attributes.hpp"
-#include "../../../core/method.tpp"
 
 SignalOutputMapItem::SignalOutputMapItem(Object& map, SignalAspect aspect) :
   OutputMapItemBase(map, aspect)

--- a/server/src/hardware/output/map/switchoutputmapitem.cpp
+++ b/server/src/hardware/output/map/switchoutputmapitem.cpp
@@ -21,7 +21,7 @@
  */
 
 #include "switchoutputmapitem.hpp"
-#include "../../../core/method.tpp"
+#include "outputmapitembase.tpp"
 
 static constexpr std::array<bool, 2> keyAliasKeys{{false, true}};
 static const std::array<std::string, 2> keyAliasValues{{"$output_map_item.switch.key:off$", "$output_map_item.switch.key:on$"}};

--- a/server/src/hardware/output/map/turnoutoutputmapitem.cpp
+++ b/server/src/hardware/output/map/turnoutoutputmapitem.cpp
@@ -22,7 +22,7 @@
 
 #include "turnoutoutputmapitem.hpp"
 
-#include "../../../core/method.tpp"
+#include "outputmapitembase.tpp"
 
 TurnoutOutputMapItem::TurnoutOutputMapItem(Object& map, TurnoutPosition position) :
   OutputMapItemBase(map, position)

--- a/server/src/hardware/output/output.cpp
+++ b/server/src/hardware/output/output.cpp
@@ -35,7 +35,7 @@ Output::Output(std::shared_ptr<OutputController> outputController, OutputChannel
   : interface{this, "interface", std::move(outputController), PropertyFlags::Constant | PropertyFlags::NoStore | PropertyFlags::ScriptReadOnly}
   , channel{this, "channel", channel_, PropertyFlags::Constant | PropertyFlags::NoStore | PropertyFlags::ScriptReadOnly}
   , type{this, "type", type_, PropertyFlags::Constant | PropertyFlags::NoStore | PropertyFlags::ScriptReadOnly}
-  , onValueChangedGeneric{*this, "on_value_changed_generic", EventFlags::Scriptable}
+  , onValueChangedGeneric{*this, "on_value_changed_generic", EventFlags::Public}
 {
   m_interfaceItems.add(interface);
 

--- a/server/src/hardware/output/output.cpp
+++ b/server/src/hardware/output/output.cpp
@@ -35,11 +35,14 @@ Output::Output(std::shared_ptr<OutputController> outputController, OutputChannel
   : interface{this, "interface", std::move(outputController), PropertyFlags::Constant | PropertyFlags::NoStore | PropertyFlags::ScriptReadOnly}
   , channel{this, "channel", channel_, PropertyFlags::Constant | PropertyFlags::NoStore | PropertyFlags::ScriptReadOnly}
   , type{this, "type", type_, PropertyFlags::Constant | PropertyFlags::NoStore | PropertyFlags::ScriptReadOnly}
+  , onValueChangedGeneric{*this, "on_value_changed_generic", EventFlags::Scriptable}
 {
   m_interfaceItems.add(interface);
 
   Attributes::addValues(channel, outputChannelValues);
   m_interfaceItems.add(channel);
+
+  m_interfaceItems.add(onValueChangedGeneric);
 }
 
 std::string Output::getObjectId() const

--- a/server/src/hardware/output/output.hpp
+++ b/server/src/hardware/output/output.hpp
@@ -29,6 +29,7 @@
 #include <traintastic/enum/outputtype.hpp>
 #include "../../core/property.hpp"
 #include "../../core/objectproperty.hpp"
+#include "../../core/event.hpp"
 
 #ifdef interface
   #undef interface // interface is defined in combaseapi.h
@@ -52,6 +53,7 @@ class Output : public Object
     ObjectProperty<OutputController> interface;
     Property<OutputChannel> channel;
     Property<OutputType> type;
+    Event<const std::shared_ptr<Output>&> onValueChangedGeneric;
 
     /**
      * \brief Unique identifier for the output within the channel.

--- a/server/src/hardware/output/pairoutput.cpp
+++ b/server/src/hardware/output/pairoutput.cpp
@@ -55,5 +55,6 @@ void PairOutput::updateValue(OutputPairValue newValue)
   if(newValue != OutputPairValue::Undefined)
   {
     fireEvent(onValueChanged, newValue, shared_ptr<PairOutput>());
+    fireEvent(onValueChangedGeneric, shared_ptr<Output>());
   }
 }

--- a/server/src/hardware/output/singleoutput.cpp
+++ b/server/src/hardware/output/singleoutput.cpp
@@ -54,5 +54,6 @@ void SingleOutput::updateValue(TriState _value)
   if(value != TriState::Undefined)
   {
     fireEvent(onValueChanged, value == TriState::True, shared_ptr<SingleOutput>());
+    fireEvent(onValueChangedGeneric, shared_ptr<Output>());
   }
 }

--- a/server/src/network/session.cpp
+++ b/server/src/network/session.cpp
@@ -30,6 +30,7 @@
 #ifndef NDEBUG
   #include "../core/eventloop.hpp" // for: isEventLoopThread()
 #endif
+#include "../core/abstractunitproperty.hpp"
 #include "../core/objectproperty.tpp"
 #include "../core/tablemodel.hpp"
 #include "../log/log.hpp"


### PR DESCRIPTION
This is still WIP

I would like to get output tiles shown on Board to react to external state changes.
For example switching a turnout from command station or handset should result in turnout rail tile showing the new position.

How to test:

1. Create 2 turnouts and assign them the same address
2. Switching one turnout should result in the other moving too