### PR TITLE
More tcb::span usage for Attributes::addValues()

### DIFF
--- a/server/src/board/tile/rail/signal/signal2aspectrailtile.cpp
+++ b/server/src/board/tile/rail/signal/signal2aspectrailtile.cpp
@@ -28,8 +28,11 @@
 #include "../../../../core/objectproperty.tpp"
 #include "../../../../hardware/output/outputcontroller.hpp"
 
-static const std::array<SignalAspect, 3> aspectValues = {SignalAspect::Stop, SignalAspect::Proceed, SignalAspect::Unknown};
-static const std::array<SignalAspect, 2> setAspectValues = {SignalAspect::Stop, SignalAspect::Proceed};
+static constexpr std::array<SignalAspect, 3> aspectValues = {
+    SignalAspect::Unknown,
+    SignalAspect::Stop,
+    SignalAspect::Proceed
+};
 
 namespace
 {
@@ -67,6 +70,9 @@ namespace
 Signal2AspectRailTile::Signal2AspectRailTile(World& world, std::string_view _id) :
   SignalRailTile(world, _id, TileId::RailSignal2Aspect)
 {
+  // Skip Unknown aspect
+  tcb::span<const SignalAspect, 2> setAspectValues = tcb::make_span(aspectValues).subspan<1>();
+
   outputMap.setValueInternal(std::make_shared<SignalOutputMap>(*this, outputMap.name(), std::initializer_list<SignalAspect>{SignalAspect::Stop, SignalAspect::Proceed}, getDefaultActionValue));
 
   Attributes::addValues(aspect, aspectValues);

--- a/server/src/board/tile/rail/signal/signal3aspectrailtile.cpp
+++ b/server/src/board/tile/rail/signal/signal3aspectrailtile.cpp
@@ -29,8 +29,12 @@
 #include "../../../../core/objectproperty.tpp"
 #include "../../../../hardware/output/outputcontroller.hpp"
 
-static const std::array<SignalAspect, 4> aspectValues = {SignalAspect::Stop, SignalAspect::ProceedReducedSpeed, SignalAspect::Proceed, SignalAspect::Unknown};
-static const std::array<SignalAspect, 3> setAspectValues = {SignalAspect::Stop, SignalAspect::ProceedReducedSpeed, SignalAspect::Proceed};
+static constexpr std::array<SignalAspect, 4> aspectValues = {
+    SignalAspect::Unknown,
+    SignalAspect::Stop,
+    SignalAspect::ProceedReducedSpeed,
+    SignalAspect::Proceed
+};
 
 namespace
 {
@@ -109,6 +113,9 @@ namespace
 Signal3AspectRailTile::Signal3AspectRailTile(World& world, std::string_view _id) :
   SignalRailTile(world, _id, TileId::RailSignal3Aspect)
 {
+  // Skip Unknown aspect
+  tcb::span<const SignalAspect, 3> setAspectValues = tcb::make_span(aspectValues).subspan<1>();
+
   outputMap.setValueInternal(std::make_shared<SignalOutputMap>(*this, outputMap.name(), std::initializer_list<SignalAspect>{SignalAspect::Stop, SignalAspect::ProceedReducedSpeed, SignalAspect::Proceed}, getDefaultActionValue));
 
   Attributes::addValues(aspect, aspectValues);

--- a/server/src/board/tile/rail/turnout/turnout3wayrailtile.cpp
+++ b/server/src/board/tile/rail/turnout/turnout3wayrailtile.cpp
@@ -25,8 +25,7 @@
 #include "../../../../core/attributes.hpp"
 #include "../../../../hardware/output/outputcontroller.hpp"
 
-static const std::array<TurnoutPosition, 4> positionValues = {TurnoutPosition::Straight, TurnoutPosition::Left, TurnoutPosition::Right, TurnoutPosition::Unknown};
-static const std::array<TurnoutPosition, 3> setPositionValues = {TurnoutPosition::Straight, TurnoutPosition::Left, TurnoutPosition::Right};
+static const std::array<TurnoutPosition, 4> positionValues = {TurnoutPosition::Unknown, TurnoutPosition::Straight, TurnoutPosition::Left, TurnoutPosition::Right};
 
 static std::optional<OutputActionValue> getDefaultActionValue(TurnoutPosition turnoutPosition, OutputType outputType, size_t outputIndex)
 {
@@ -40,6 +39,9 @@ static std::optional<OutputActionValue> getDefaultActionValue(TurnoutPosition tu
 Turnout3WayRailTile::Turnout3WayRailTile(World& world, std::string_view _id)
   : TurnoutRailTile(world, _id, TileId::RailTurnout3Way, 4)
 {
+  // Skip Unknown position
+  tcb::span<const TurnoutPosition, 3> setPositionValues = tcb::make_span(positionValues).subspan<1>();
+
   outputMap.setValueInternal(std::make_shared<TurnoutOutputMap>(*this, outputMap.name(), std::initializer_list<TurnoutPosition>{TurnoutPosition::Straight, TurnoutPosition::Left, TurnoutPosition::Right}, getDefaultActionValue));
 
   Attributes::addValues(position, positionValues);

--- a/server/src/board/tile/rail/turnout/turnoutdoublesliprailtile.cpp
+++ b/server/src/board/tile/rail/turnout/turnoutdoublesliprailtile.cpp
@@ -25,13 +25,10 @@
 #include "../../../../core/objectproperty.tpp"
 #include "../../../../hardware/output/outputcontroller.hpp"
 
-static const std::array<TurnoutPosition, 7> positionValues = {TurnoutPosition::Left, TurnoutPosition::Right,
+static const std::array<TurnoutPosition, 7> positionValues = {TurnoutPosition::Unknown,
+                                                              TurnoutPosition::Left, TurnoutPosition::Right,
                                                               TurnoutPosition::Crossed, TurnoutPosition::Diverged,
-                                                              TurnoutPosition::DoubleSlipStraightA, TurnoutPosition::DoubleSlipStraightB,
-                                                              TurnoutPosition::Unknown};
-static const std::array<TurnoutPosition, 6> setPositionValues = {TurnoutPosition::Left, TurnoutPosition::Right,
-                                                                 TurnoutPosition::Crossed, TurnoutPosition::Diverged,
-                                                                 TurnoutPosition::DoubleSlipStraightA, TurnoutPosition::DoubleSlipStraightB};
+                                                              TurnoutPosition::DoubleSlipStraightA, TurnoutPosition::DoubleSlipStraightB};
 
 static std::optional<OutputActionValue> getDefaultActionValue(TurnoutPosition turnoutPosition, OutputType outputType, size_t outputIndex)
 {
@@ -45,6 +42,9 @@ static std::optional<OutputActionValue> getDefaultActionValue(TurnoutPosition tu
 TurnoutDoubleSlipRailTile::TurnoutDoubleSlipRailTile(World& world, std::string_view _id)
   : TurnoutRailTile(world, _id, TileId::RailTurnoutDoubleSlip, 4)
 {
+  // Skip Unknown position
+  tcb::span<const TurnoutPosition, 6> setPositionValues = tcb::make_span(positionValues).subspan<1>();
+
   outputMap.setValueInternal(std::make_shared<TurnoutOutputMap>(*this, outputMap.name(),
                                                                 std::initializer_list<TurnoutPosition>{
                                                                     TurnoutPosition::Left, TurnoutPosition::Right,

--- a/server/src/board/tile/rail/turnout/turnoutleftrailtile.cpp
+++ b/server/src/board/tile/rail/turnout/turnoutleftrailtile.cpp
@@ -25,8 +25,7 @@
 #include "../../../../core/objectproperty.tpp"
 #include "../../../../hardware/output/outputcontroller.hpp"
 
-static const std::array<TurnoutPosition, 3> positionValues = {TurnoutPosition::Straight, TurnoutPosition::Left, TurnoutPosition::Unknown};
-static const std::array<TurnoutPosition, 2> setPositionValues = {TurnoutPosition::Straight, TurnoutPosition::Left};
+static const std::array<TurnoutPosition, 3> positionValues = {TurnoutPosition::Unknown, TurnoutPosition::Straight, TurnoutPosition::Left};
 
 static std::optional<OutputActionValue> getDefaultActionValue(TurnoutPosition turnoutPosition, OutputType outputType, size_t outputIndex)
 {
@@ -67,6 +66,9 @@ static std::optional<OutputActionValue> getDefaultActionValue(TurnoutPosition tu
 TurnoutLeftRailTile::TurnoutLeftRailTile(World& world, std::string_view _id, TileId tileId)
   : TurnoutRailTile(world, _id, tileId, 3)
 {
+  // Skip Unknown position
+  tcb::span<const TurnoutPosition, 2> setPositionValues = tcb::make_span(positionValues).subspan<1>();
+
   outputMap.setValueInternal(std::make_shared<TurnoutOutputMap>(*this, outputMap.name(), std::initializer_list<TurnoutPosition>{TurnoutPosition::Straight, TurnoutPosition::Left}, getDefaultActionValue));
 
   Attributes::addValues(position, positionValues);

--- a/server/src/board/tile/rail/turnout/turnoutrightrailtile.cpp
+++ b/server/src/board/tile/rail/turnout/turnoutrightrailtile.cpp
@@ -25,8 +25,7 @@
 #include "../../../../core/objectproperty.tpp"
 #include "../../../../hardware/output/outputcontroller.hpp"
 
-static const std::array<TurnoutPosition, 3> positionValues = {TurnoutPosition::Straight, TurnoutPosition::Right, TurnoutPosition::Unknown};
-static const std::array<TurnoutPosition, 2> setPositionValues = {TurnoutPosition::Straight, TurnoutPosition::Right};
+static const std::array<TurnoutPosition, 3> positionValues = {TurnoutPosition::Unknown, TurnoutPosition::Straight, TurnoutPosition::Right};
 
 static std::optional<OutputActionValue> getDefaultActionValue(TurnoutPosition turnoutPosition, OutputType outputType, size_t outputIndex)
 {
@@ -67,6 +66,9 @@ static std::optional<OutputActionValue> getDefaultActionValue(TurnoutPosition tu
 TurnoutRightRailTile::TurnoutRightRailTile(World& world, std::string_view _id, TileId tileId)
   : TurnoutRailTile(world, _id, tileId, 3)
 {
+  // Skip Unknown position
+  tcb::span<const TurnoutPosition, 2> setPositionValues = tcb::make_span(positionValues).subspan<1>();
+
   outputMap.setValueInternal(std::make_shared<TurnoutOutputMap>(*this, outputMap.name(), std::initializer_list<TurnoutPosition>{TurnoutPosition::Straight, TurnoutPosition::Right}, getDefaultActionValue));
 
   Attributes::addValues(position, positionValues);

--- a/server/src/board/tile/rail/turnout/turnoutsinglesliprailtile.cpp
+++ b/server/src/board/tile/rail/turnout/turnoutsinglesliprailtile.cpp
@@ -25,11 +25,9 @@
 #include "../../../../core/objectproperty.tpp"
 #include "../../../../hardware/output/outputcontroller.hpp"
 
-static const std::array<TurnoutPosition, 5> positionValues = {TurnoutPosition::Crossed, TurnoutPosition::Diverged,
-                                                              TurnoutPosition::DoubleSlipStraightA, TurnoutPosition::DoubleSlipStraightB,
-                                                              TurnoutPosition::Unknown};
-static const std::array<TurnoutPosition, 4> setPositionValues = {TurnoutPosition::Crossed, TurnoutPosition::Diverged,
-                                                                 TurnoutPosition::DoubleSlipStraightA, TurnoutPosition::DoubleSlipStraightB};
+static const std::array<TurnoutPosition, 5> positionValues = {TurnoutPosition::Unknown,
+                                                              TurnoutPosition::Crossed, TurnoutPosition::Diverged,
+                                                              TurnoutPosition::DoubleSlipStraightA, TurnoutPosition::DoubleSlipStraightB,};
 
 static std::optional<OutputActionValue> getDefaultActionValue(TurnoutPosition turnoutPosition, OutputType outputType, size_t outputIndex)
 {
@@ -43,6 +41,9 @@ static std::optional<OutputActionValue> getDefaultActionValue(TurnoutPosition tu
 TurnoutSingleSlipRailTile::TurnoutSingleSlipRailTile(World& world, std::string_view _id)
   : TurnoutRailTile(world, _id, TileId::RailTurnoutSingleSlip, 4)
 {
+  // Skip Unknown position
+  tcb::span<const TurnoutPosition, 4> setPositionValues = tcb::make_span(positionValues).subspan<1>();
+
   outputMap.setValueInternal(std::make_shared<TurnoutOutputMap>(*this, outputMap.name(),
                                                                   std::initializer_list<TurnoutPosition>{
                                                                     TurnoutPosition::Crossed, TurnoutPosition::Diverged,

--- a/server/src/board/tile/rail/turnout/turnoutwyerailtile.cpp
+++ b/server/src/board/tile/rail/turnout/turnoutwyerailtile.cpp
@@ -25,8 +25,7 @@
 #include "../../../../core/objectproperty.tpp"
 #include "../../../../hardware/output/outputcontroller.hpp"
 
-static const std::array<TurnoutPosition, 3> positionValues = {TurnoutPosition::Left, TurnoutPosition::Right, TurnoutPosition::Unknown};
-static const std::array<TurnoutPosition, 2> setPositionValues = {TurnoutPosition::Left, TurnoutPosition::Right};
+static const std::array<TurnoutPosition, 3> positionValues = {TurnoutPosition::Unknown, TurnoutPosition::Left, TurnoutPosition::Right};
 
 static std::optional<OutputActionValue> getDefaultActionValue(TurnoutPosition turnoutPosition, OutputType outputType, size_t outputIndex)
 {
@@ -40,6 +39,9 @@ static std::optional<OutputActionValue> getDefaultActionValue(TurnoutPosition tu
 TurnoutWyeRailTile::TurnoutWyeRailTile(World& world, std::string_view _id)
   : TurnoutRailTile(world, _id, TileId::RailTurnoutWye, 3)
 {
+  // Skip Unknown position
+  tcb::span<const TurnoutPosition, 2> setPositionValues = tcb::make_span(positionValues).subspan<1>();
+
   outputMap.setValueInternal(std::make_shared<TurnoutOutputMap>(*this, outputMap.name(), std::initializer_list<TurnoutPosition>{TurnoutPosition::Left, TurnoutPosition::Right}, getDefaultActionValue));
 
   Attributes::addValues(position, positionValues);

--- a/server/src/core/attributes.hpp
+++ b/server/src/core/attributes.hpp
@@ -261,14 +261,14 @@ struct Attributes
     method.addAttribute(AttributeName::Values, values);
   }
 
-  template<class R, class T>
-  static inline void addValues(Method<R(T)>& method, tcb::span<const T> values)
+  template<class R, class T, size_t N>
+  static inline void addValues(Method<R(T)>& method, tcb::span<const T, N> values)
   {
     method.addAttribute(AttributeName::Values, values);
   }
 
-  template<typename T>
-  static inline void addValues(Property<T>& property, tcb::span<const T> values)
+  template<typename T, size_t N>
+  static inline void addValues(Property<T>& property, tcb::span<const T, N> values)
   {
     property.addAttribute(AttributeName::Values, values);
   }
@@ -309,8 +309,8 @@ struct Attributes
     method.addAttribute(AttributeName::Values, std::move(values));
   }
 
-  template<typename T>
-  static inline void setValues(Property<T>& property, tcb::span<const T> values)
+  template<typename T, size_t N>
+  static inline void setValues(Property<T>& property, tcb::span<const T, N> values)
   {
     property.setAttribute(AttributeName::Values, values);
   }

--- a/server/src/core/interfaceitem.hpp
+++ b/server/src/core/interfaceitem.hpp
@@ -53,17 +53,17 @@ class InterfaceItem
       m_attributes.emplace(name, std::make_unique<Attribute<T>>(*this, name, value));
     }
 
-    template<typename T>
-    void addAttribute(AttributeName name, tcb::span<const T> values)
+    template<typename T, size_t N>
+    void addAttribute(AttributeName name, tcb::span<const T, N> values)
     {
       assert(m_attributes.find(name) == m_attributes.end());
-      m_attributes.emplace(name, std::make_unique<SpanAttribute<T>>(*this, name, values));
+      m_attributes.emplace(name, std::make_unique<SpanAttribute<T, N>>(*this, name, values));
     }
 
     template<typename T, size_t N>
     void addAttribute(AttributeName name, const std::array<T, N>& values)
     {
-      addAttribute(name, tcb::span<const T>{values.data(), values.size()});
+      addAttribute(name, tcb::span<const T, N>{values.data(), values.size()});
     }
 
     template<typename T>
@@ -87,11 +87,11 @@ class InterfaceItem
       static_cast<Attribute<T>*>(m_attributes[name].get())->setValue(value);
     }
 
-    template<typename T>
-    void setAttribute(AttributeName name, tcb::span<const T> values)
+    template<typename T, size_t N>
+    void setAttribute(AttributeName name, tcb::span<const T, N> values)
     {
       assert(m_attributes.find(name) != m_attributes.end());
-      static_cast<SpanAttribute<T>*>(m_attributes[name].get())->setValues(values);
+      static_cast<SpanAttribute<T, N>*>(m_attributes[name].get())->setValues(values);
     }
 
     template<typename T>

--- a/server/src/core/spanattribute.hpp
+++ b/server/src/core/spanattribute.hpp
@@ -27,14 +27,17 @@
 #include "abstractvaluesattribute.hpp"
 #include "to.hpp"
 
-template<typename T>
+template<typename T, size_t N = tcb::dynamic_extent>
 class SpanAttribute : public AbstractValuesAttribute
 {
+  public:
+    typedef tcb::span<const T, N> Span;
+
   protected:
-    tcb::span<const T> m_values;
+    Span m_values;
 
   public:
-    SpanAttribute(InterfaceItem& _item, AttributeName _name, tcb::span<const T> values) :
+    SpanAttribute(InterfaceItem& _item, AttributeName _name, Span values) :
       AbstractValuesAttribute(_item, _name, value_type_v<T>),
       m_values{values}
     {
@@ -70,12 +73,12 @@ class SpanAttribute : public AbstractValuesAttribute
       return to<std::string>(m_values[index]);
     }
 
-    tcb::span<const T> values() const
+    Span values() const
     {
       return m_values;
     }
 
-    void setValues(tcb::span<const T> values)
+    void setValues(Span values)
     {
       if(m_values.size() != values.size() || !std::equal(m_values.begin(), m_values.end(), values.begin()) || m_values.data() == values.data())
       {


### PR DESCRIPTION
- Invert template order in Attributes::addValues()
- Unfortunately template parameter is not deduced automatically because of `const` in span template
- More could be done for OutputMap