### PR TITLE
server: Z21 fix LanXTurnoutInfo member order

### DIFF
--- a/server/src/hardware/protocol/z21/messages.hpp
+++ b/server/src/hardware/protocol/z21/messages.hpp
@@ -1103,8 +1103,8 @@ static_assert(sizeof(LanGetHardwareInfoReply) == 12);
 // LAN_X_TURNOUT_INFO
 struct LanXTurnoutInfo : LanX
 {
-  uint8_t addressLSB;
   uint8_t addressMSB;
+  uint8_t addressLSB;
   uint8_t db2;
   uint8_t checksum;
 


### PR DESCRIPTION
Most significant address byte is first (DB0)

This fixes parsing of `LAN_X_TURNOUT_INFO` replies from Z21 which would otherwise activate wrong output once #113 gets merged.

Also `LAN_X_EXT_ACCESSORY_INFO` and `LAN_X_GET_EXT_ACCESSORY_INFO` are missing. I'll draft an implementation.