### PR TITLE
Fix z21 power state

### DIFF
--- a/server/src/hardware/protocol/z21/messages.hpp
+++ b/server/src/hardware/protocol/z21/messages.hpp
@@ -391,7 +391,7 @@ static_assert(sizeof(LanXSetTrackPowerOff) == 7);
 // LAN_X_SET_TRACK_POWER_ON
 struct LanXSetTrackPowerOn : LanX
 {
-  uint8_t db0 = LAN_X_SET_TRACK_POWER_OFF;
+  uint8_t db0 = LAN_X_SET_TRACK_POWER_ON;
   uint8_t checksum = 0xa0;
 
   LanXSetTrackPowerOn() :


### PR DESCRIPTION
This fixes power state changes being ignored from both end at times or annoying repeated changes in loop.

By the way, I've finally succeeded in making myself a small Z21 with an ESP32 and using Philipp Gahtow libraries ([available here](https://www.pgahtow.de/w/Z21_mobile/en)) with some patches on top to make it work better and as an XpressNet slave.

![ESP32_Z21_mia](https://github.com/traintastic/traintastic/assets/42845724/6c13d400-40bc-444e-b2a9-b253c56393d4)

I cannot test with a real Z21 but you maybe could test with Digikeijs DR5000.

Should fix #85 
