### PR TITLE
removed system requirement for lsb_release

### DIFF
--- a/shared/traintastic.cmake
+++ b/shared/traintastic.cmake
@@ -24,7 +24,7 @@ endif()
 
 # Debian package
 if(LINUX)
-  cmake_host_system_information(RESULT DISTRO QUERY DISTRIB_ID_LIKE)
+  cmake_host_system_information(RESULT DISTRO QUERY DISTRIB_ID)
   cmake_host_system_information(RESULT CODENAME QUERY DISTRIB_VERSION_CODENAME)
 
   message(STATUS "distro id is ${DISTRO}")

--- a/shared/traintastic.cmake
+++ b/shared/traintastic.cmake
@@ -24,16 +24,13 @@ endif()
 
 # Debian package
 if(LINUX)
-  execute_process(COMMAND lsb_release -i -s OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE LSB_RELEASE_ID)
-  execute_process(COMMAND lsb_release -c -s OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE LSB_RELEASE_CODENAME)
+  cmake_host_system_information(RESULT DISTRO QUERY DISTRIB_ID_LIKE)
+  cmake_host_system_information(RESULT CODENAME QUERY DISTRIB_VERSION_CODENAME)
 
-  string(TOLOWER ${LSB_RELEASE_ID} LSB_RELEASE_ID)
-  string(TOLOWER ${LSB_RELEASE_CODENAME} LSB_RELEASE_CODENAME)
+  message(STATUS "distro id is ${DISTRO}")
+  message(STATUS "release codename is ${CODENAME}")
 
-  message(STATUS "lsb_release id is ${LSB_RELEASE_ID}")
-  message(STATUS "lsb_release codename is ${LSB_RELEASE_CODENAME}")
-
-  string(REPLACE "-" "~" DEBIAN_PACKAGE_VERSION_EXTRA ~${LSB_RELEASE_ID}~${LSB_RELEASE_CODENAME}${TRAINTASTIC_VERSION_EXTRA})
+  string(REPLACE "-" "~" DEBIAN_PACKAGE_VERSION_EXTRA ~${DISTRO}~${CODENAME}${TRAINTASTIC_VERSION_EXTRA})
 endif()
 
 # Debug


### PR DESCRIPTION
removed system level requirement for lsb_release which isn't always installed on all Linux distros.

Cmake has an inbuilt function for getting host system-level environment variables.

https://cmake.org/cmake/help/latest/command/cmake_host_system_information.html#query-host-system-specific-information