### PR TITLE
Fixed new line character skipping

### DIFF
--- a/server/src/hardware/protocol/loconet/iohandler/lbserveriohandler.cpp
+++ b/server/src/hardware/protocol/loconet/iohandler/lbserveriohandler.cpp
@@ -145,8 +145,11 @@ void LBServerIOHandler::read()
             m_version = line.substr(7);
           }
 
-          pos += line.size();
-          bytesTransferred -= line.size();
+          pos = eol + 1; // Skip the newline character
+          if (pos < end && (*pos == '\n' || *pos == '\r') && *pos != *(pos - 1)) {
+            pos++; // Skip the second part of CRLF or LFCR
+          }
+          bytesTransferred = end - pos;
         }
 
         if(bytesTransferred != 0)


### PR DESCRIPTION
 \n\r handles in both directions as well \r\n as well as just \n or \r

Got stuck in a loop after reading the new line character it didn't count it in the loop, so ignored it and kept looping.