### PR TITLE
Unlatch momentary functions after specified timeout

### DIFF
--- a/server/src/hardware/decoder/decoder.cpp
+++ b/server/src/hardware/decoder/decoder.cpp
@@ -29,6 +29,7 @@
 #include "../protocol/dcc/dcc.hpp"
 #include "../throttle/throttle.hpp"
 #include "../../world/world.hpp"
+#include "../../core/eventloop.hpp"
 #include "../../core/objectproperty.tpp"
 #include "../../core/attributes.hpp"
 #include "../../core/method.tpp"
@@ -42,6 +43,8 @@ const std::shared_ptr<Decoder> Decoder::null;
 
 Decoder::Decoder(World& world, std::string_view _id) :
   IdObject(world, _id),
+  m_functionLatchTimer{EventLoop::ioContext},
+  m_currentLatchedFunction(NO_FUNCTION),
   name{this, "name", "", PropertyFlags::ReadWrite | PropertyFlags::Store},
   interface{this, "interface", nullptr, PropertyFlags::ReadWrite | PropertyFlags::Store,
     [this](const std::shared_ptr<DecoderController>& value)
@@ -268,7 +271,7 @@ void Decoder::setFunctionValue(uint32_t number, bool value)
 {
   const auto& f = getFunction(number);
   if(f && getFunctionValue(f) != value)
-    f->value.setValueInternal(value);
+    f->value.setValue(value);
 }
 
 bool Decoder::acquire(Throttle& driver, bool steal)
@@ -441,4 +444,79 @@ void Decoder::changed(DecoderChangeFlags changes, uint32_t functionNumber)
   if(interface)
     interface->decoderChanged(*this, changes, functionNumber);
   decoderChanged(*this, changes, functionNumber);
+
+  if(has(changes, DecoderChangeFlags::FunctionValue))
+  {
+    const auto& f = getFunction(functionNumber);
+    if(m_currentLatchedFunction == functionNumber && (!f || f->value == false))
+    {
+      // Stop scheduled unlatch for current function, check other functions
+      rescheduleLatchedFunctionTimer();
+    }
+    else if(f && f->value == true && f->timeoutSeconds.value() > 0)
+    {
+      if(m_currentLatchedFunction == NO_FUNCTION)
+      {
+        // Schedule new timer
+        rescheduleLatchedFunctionTimer();
+      }
+      else if(m_currentLatchedFunction != functionNumber && f->getScheduledTimeout() < m_functionLatchTimer.expiry())
+      {
+        // If we timeout before current scheduled timer to this function
+        rescheduleLatchedFunctionTimer();
+      }
+    }
+  }
+}
+
+void Decoder::rescheduleLatchedFunctionTimer()
+{
+  if(m_currentLatchedFunction != NO_FUNCTION)
+  {
+    // Cancel current active timer before rescheduling
+    m_currentLatchedFunction = NO_FUNCTION;
+    m_functionLatchTimer.cancel();
+  }
+
+  std::chrono::steady_clock::time_point m_firstTimeout;
+
+  for(const auto& f : *functions)
+  {
+    if(f->timeoutSeconds.value() > 0 && f->value == true)
+    {
+      const auto scheduledTimout = f->getScheduledTimeout();
+      if(m_currentLatchedFunction == NO_FUNCTION || scheduledTimout < m_firstTimeout)
+      {
+        // We are the first function to timeout
+        m_firstTimeout = scheduledTimout;
+        m_currentLatchedFunction = f->number;
+      }
+    }
+  }
+
+  // Only start timer if needed
+  if(m_currentLatchedFunction != NO_FUNCTION)
+  {
+    m_functionLatchTimer.expires_at(m_firstTimeout);
+    m_functionLatchTimer.async_wait(std::bind(&Decoder::onLatchFunctionTimeout, this, std::placeholders::_1));
+  }
+}
+
+void Decoder::onLatchFunctionTimeout(const boost::system::error_code& ec)
+{
+  if(ec)
+    return; // Do nothing if we get cancelled
+
+  assert(m_currentLatchedFunction != NO_FUNCTION);
+
+  uint32_t currentLatchedFunction = m_currentLatchedFunction;
+
+  // Reset current latched function to allow rescheduling
+  m_currentLatchedFunction = NO_FUNCTION;
+
+  // We have not been cancelled, turn off latched function
+  const auto& f = getFunction(currentLatchedFunction);
+  f->value.setValue(false);
+
+  rescheduleLatchedFunctionTimer();
 }

--- a/server/src/hardware/decoder/decoder.hpp
+++ b/server/src/hardware/decoder/decoder.hpp
@@ -24,6 +24,7 @@
 #define TRAINTASTIC_SERVER_HARDWARE_DECODER_DECODER_HPP
 
 #include <type_traits>
+#include <boost/asio/steady_timer.hpp>
 #include "../../core/idobject.hpp"
 #include "../../core/objectproperty.hpp"
 #include <traintastic/enum/decoderprotocol.hpp>
@@ -47,6 +48,10 @@ class Decoder : public IdObject
     bool m_worldMute;
     bool m_worldNoSmoke;
     std::shared_ptr<Throttle> m_driver;
+
+    boost::asio::steady_timer m_functionLatchTimer;
+    uint32_t m_currentLatchedFunction;
+    static constexpr uint32_t NO_FUNCTION = std::numeric_limits<uint32_t>::max();
 
   protected:
     void loaded() final;
@@ -74,7 +79,17 @@ class Decoder : public IdObject
     void updateEditable(bool editable);
     void changed(DecoderChangeFlags changes, uint32_t functionNumber = 0);
 
-  public:
+    //! \brief Schedule timer to turn off latched momentary function
+    //! This function cancels current active timer and searches for other active
+    //! momentary functions. If no momentary function is active no timer is scheduled.
+    void rescheduleLatchedFunctionTimer();
+
+    //! \brief Timer handler which actually turns off the function
+    //! If not cancelled then it calls \ref rescheduleLatchedFunctionTimer() to check
+    //! for other active momentary functions.
+    void onLatchFunctionTimeout(const boost::system::error_code &ec);
+
+public:
     CLASS_ID("decoder")
     CREATE_DEF(Decoder)
 

--- a/server/src/hardware/decoder/decoderfunction.hpp
+++ b/server/src/hardware/decoder/decoderfunction.hpp
@@ -23,6 +23,7 @@
 #ifndef TRAINTASTIC_SERVER_HARDWARE_DECODER_DECODERFUNCTION_HPP
 #define TRAINTASTIC_SERVER_HARDWARE_DECODER_DECODERFUNCTION_HPP
 
+#include <chrono>
 #include "../../core/object.hpp"
 #include "../../core/property.hpp"
 #include "../../enum/decoderfunctiontype.hpp"
@@ -38,6 +39,8 @@ class DecoderFunction : public Object
   protected:
     Decoder& m_decoder;
 
+    std::chrono::steady_clock::time_point m_scheduledTimeout;
+
     void loaded() override;
     void worldEvent(WorldState state, WorldEvent event) final;
 
@@ -52,12 +55,22 @@ class DecoderFunction : public Object
     Property<DecoderFunctionFunction> function;
     Property<bool> value;
 
+    //! \brief Timeout in seconds to unlatch (turn off) active momentary functions
+    //! If set to zero, functions will not be automatically turned off
+    //! Active only for \ref DecoderFunctionType::Momentary and \ref DecoderFunctionType::Hold
+    Property<int> timeoutSeconds;
+
     DecoderFunction(Decoder& decoder, uint8_t _number);
 
     std::string getObjectId() const final;
 
     const Decoder& decoder() const { return m_decoder; }
     Decoder& decoder() { return m_decoder; }
+
+    inline const std::chrono::steady_clock::time_point& getScheduledTimeout() const
+    {
+      return m_scheduledTimeout;
+    }
 };
 
 #endif

--- a/server/src/hardware/protocol/z21/clientkernel.cpp
+++ b/server/src/hardware/protocol/z21/clientkernel.cpp
@@ -296,15 +296,16 @@ void ClientKernel::receive(const Message& message)
                       decoder->throttle = throttle;
                     }
 
-                    //Reset flag guard at end
-                    m_isUpdatingDecoderFromKernel = false;
-
                     //Function get always updated because we do not store a copy in cache
                     //so there is no way to tell in advance if they changed
                     for(int i = 0; i <= functionIndexMax; i++)
                     {
+                      m_isUpdatingDecoderFromKernel = true;
                       decoder->setFunctionValue(i, val[i]);
                     }
+
+                    //Reset flag guard at end
+                    m_isUpdatingDecoderFromKernel = false;
                   }
                 }
                 catch(...)


### PR DESCRIPTION
Second commit is an adaption for Z21 ClientKernel. It should be done also for other interfaces.

See #161 