### PR TITLE
Revert "server: Z21 ClientKernel fix crash on disconnect"

### DIFF
--- a/server/src/hardware/protocol/z21/clientkernel.cpp
+++ b/server/src/hardware/protocol/z21/clientkernel.cpp
@@ -55,9 +55,9 @@ void ClientKernel::receive(const Message& message)
 {
   if(m_config.debugLogRXTX)
     EventLoop::call(
-      [logId_=logId, msg=toString(message)]()
+      [this, msg=toString(message)]()
       {
-        Log::log(logId_, LogMessage::D2002_RX_X, msg);
+        Log::log(logId, LogMessage::D2002_RX_X, msg);
       });
 
   switch(message.header())
@@ -807,9 +807,9 @@ void ClientKernel::send(const Message& message)
   {
     if(m_config.debugLogRXTX)
       EventLoop::call(
-        [logId_=logId, msg=toString(message)]()
+        [this, msg=toString(message)]()
         {
-          Log::log(logId_, LogMessage::D2001_TX_X, msg);
+          Log::log(logId, LogMessage::D2001_TX_X, msg);
         });
   }
   else


### PR DESCRIPTION
This reverts commit 5a291f0c914c904c98dcd3d1f0434f05bf31f39e.

This workaround is not needed anymore after commit 161a0e9521bc3ef30c799234d3f82d84b971afdd