### PR TITLE
[simulator] fix start_point origin angle

### DIFF
--- a/shared/src/traintastic/simulator/simulator.cpp
+++ b/shared/src/traintastic/simulator/simulator.cpp
@@ -724,7 +724,7 @@ Simulator::StaticData Simulator::load(const nlohmann::json& world, StateData& st
             const auto pt = startSegment.origin();
             curX = pt.x;
             curY = pt.y;
-            curRotation = startSegment.rotation;
+            curRotation = startSegment.rotation + pi;
 
             lastSide = Side::Origin;
             lastSegmentIndex = it->second;


### PR DESCRIPTION
This partially fixes turnouts starting from other segments origin.